### PR TITLE
 feat: 모집하기 - 면접관 일정 확인 컴포넌트

### DIFF
--- a/public/assets/ic-nextDate.svg
+++ b/public/assets/ic-nextDate.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 11L6 6L1 1" stroke="#8B8FA4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/ic-prevDate.svg
+++ b/public/assets/ic-prevDate.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 11L1 6L6 1" stroke="#8B8FA4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/recruting/_01_plan/PrepareStepRoles.tsx
+++ b/src/components/recruting/_01_plan/PrepareStepRoles.tsx
@@ -209,7 +209,8 @@ export default function PrepareStepRoles() {
           <p className="text-state-error ">{errors.steps.message}</p>
         )}
       </div>
-      제출 버튼
+
+      {/* 제출 버튼
       <div className="flex justify-end mt-6 mr-[48px]">
         <button
           type="submit"
@@ -217,7 +218,7 @@ export default function PrepareStepRoles() {
         >
           저장하기
         </button>
-      </div>
+      </div> */}
     </form>
   );
 }

--- a/src/components/recruting/_01_plan/PrepareStepRoles.tsx
+++ b/src/components/recruting/_01_plan/PrepareStepRoles.tsx
@@ -96,10 +96,12 @@ export default function PrepareStepRoles() {
       <div className="ml-[22px] mr-[39px] flex justify-between">
         <div className="flex">
           <p className="section-title">
-            <span className="mr-[0.25em] text-main-100">*</span>모집 준비 단계
-            역할 분담
+            <span className="mr-[0.25em] text-main-100">*</span>면접관 일정
+            확인하기 역할 분담
           </p>
-          <div className="tooltip">우리 동아리의 인재상을 작성해 주세요.</div>
+          <div className="tooltip">
+            면접에 들어갈 면접관 수에 맞게 클릭해 확정해 주세요.
+          </div>
         </div>
 
         <button

--- a/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
+++ b/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
@@ -1,8 +1,62 @@
+import { time } from "console";
 import { useState } from "react";
 
 export default function AdminsSchedule() {
-  const [selectDate, setSelectDate] = useState(false);
-  const [selectAdmin, setSelectAdmin] = useState(false);
+  // const [selectAdmin, setSelectAdmin] = useState(false);
+
+  interface TimeSlotAdmins {
+    [timeSlot: string]: string[];
+  }
+  // 각 시간대별 선택된 면접관을 관리하는 상태
+  const [timeSlotAdmins, setTimeSlotAdmins] = useState<TimeSlotAdmins>({});
+
+  //일단 시간대 임의로 써놨습니다..!
+  const timeSlots = [
+    "9:00AM",
+    "10:00AM",
+    "11:00AM",
+    "2:00PM",
+    "3:00PM",
+    "4:00PM"
+  ];
+
+  //임원진도 임의로 써놨습니다!
+  const admins = ["박시현", "윤다인", "곽서연", "최예은"];
+
+  const handleAdminSelect = (timeSlot: string, admin: string) => {
+    setTimeSlotAdmins((prev) => {
+      const currentAdmins = prev[timeSlot] || [];
+
+      // 이미 선택된 면접관이면 제거
+      if (currentAdmins.includes(admin)) {
+        return {
+          ...prev,
+          [timeSlot]: currentAdmins.filter((a: string) => a !== admin)
+        };
+      }
+
+      // 2명 이상 선택되어 있으면 선택 불가
+      if (currentAdmins.length >= 2) {
+        return prev;
+      }
+
+      // 새로운 면접관 추가
+      return {
+        ...prev,
+        [timeSlot]: [...currentAdmins, admin]
+      };
+    });
+  };
+
+  // 특정 시간대에 면접관이 선택되어 있는지 확인하는 함수
+  const isAdminSelectedForTimeSlot = (timeSlot: string, admin: string) => {
+    return timeSlotAdmins[timeSlot]?.includes(admin) || false;
+  };
+
+  // 특정 시간대에 선택된 면접관 수를 반환하는 함수
+  const getSelectedAdminCount = (timeSlot: string) => {
+    return timeSlotAdmins[timeSlot]?.length || 0;
+  };
 
   return (
     <div>
@@ -38,23 +92,34 @@ export default function AdminsSchedule() {
                   />
                 </div>
                 <div className="pt-2 pb-[10px] pl-[11px]">
-                  {/*이게 한 묶음 */}
-                  <div className="flex items-center">
-                    {/*시간*/}
+                  {timeSlots.map((timeSlot) => (
                     <div
-                      onClick={() => setSelectDate(!selectDate)}
-                      className={`flex-center w-[77.85px] mr-[10.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border ${selectDate ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]`}
+                      key={timeSlot}
+                      className="flex items-center space-x-[7px] mb-[13px] "
                     >
-                      9:00AM
+                      {/*시간*/}
+                      <div
+                        className={`flex-center w-[77.85px] mr-[3.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border ${getSelectedAdminCount(timeSlot) >= 2 ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2`}
+                      >
+                        {timeSlot}
+                      </div>
+                      {/*운영진들 */}
+                      {admins.map((admin) => (
+                        <button
+                          key={`${timeSlot}-${admin}`}
+                          onClick={() => handleAdminSelect(timeSlot, admin)}
+                          disabled={
+                            getSelectedAdminCount(timeSlot) >= 2 &&
+                            !isAdminSelectedForTimeSlot(timeSlot, admin)
+                          }
+                          className={`flex-center w-[77.85px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]
+                            ${isAdminSelectedForTimeSlot(timeSlot, admin) ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover-not-allowed`}
+                        >
+                          {admin}
+                        </button>
+                      ))}
                     </div>
-                    {/*운영진들 */}
-                    <div
-                      onClick={() => setSelectAdmin(!selectAdmin)}
-                      className={`flex-center w-[77.85px] h-7 mr-[7px] bg-[#FBFBFF] rounded-[6px] cursor-pointer border ${selectAdmin ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]`}
-                    >
-                      박시현
-                    </div>
-                  </div>
+                  ))}
                 </div>
               </div>
             </div>

--- a/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
+++ b/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+export default function AdminsSchedule() {
+  const [selectDate, setSelectDate] = useState(false);
+  const [selectAdmin, setSelectAdmin] = useState(false);
+
+  return (
+    <div>
+      <div className="ml-8 w-full mt-[34px]">
+        <div>
+          <div className="flex">
+            <p className="section-title">
+              <span className="mr-[0.25em] text-main-100">*</span>면접관 일정
+              확정하기
+            </p>
+            <div className="tooltip">
+              면접에 들어갈 면접관 수에 맞게 클릭해 확정해 주세요.
+            </div>
+          </div>
+          <div className=" ">
+            <div className="mt-[16px] h-auto pt-[29px] px-[30px] pb-[40px] bg-white-100 rounded-[12px]">
+              <p className="text-main-100 text-caption3 text-left">
+                면접에 들어갈 2명을 선택해 주세요. 2명이 가능한 시간을 이후에
+                지원자들이 선택할 수 있습니다.
+              </p>
+              <div className="mt-3 border border-gray-300 rounded-[12px] bg-[#FBFBFF]">
+                <div className="flex-center bg-gray-200 border-b-[#C7C7CC rounded-t-[12px] pt-[15px] pb-[14px] text-headline">
+                  <img
+                    src="/assets/ic-prevDate.svg"
+                    alt="이전 날짜"
+                    className="mr-[6px]"
+                  />
+                  <p>10월 13일 월요일</p> {/*날짜*/}
+                  <img
+                    src="/assets/ic-nextDate.svg"
+                    alt="다음 날짜"
+                    className="ml-[6px]"
+                  />
+                </div>
+                <div className="pt-2 pb-[10px] pl-[11px]">
+                  {/*이게 한 묶음 */}
+                  <div className="flex items-center">
+                    {/*시간*/}
+                    <div
+                      onClick={() => setSelectDate(!selectDate)}
+                      className={`flex-center w-[77.85px] mr-[10.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border ${selectDate ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]`}
+                    >
+                      9:00AM
+                    </div>
+                    {/*운영진들 */}
+                    <div
+                      onClick={() => setSelectAdmin(!selectAdmin)}
+                      className={`flex-center w-[77.85px] h-7 mr-[7px] bg-[#FBFBFF] rounded-[6px] cursor-pointer border ${selectAdmin ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]`}
+                    >
+                      박시현
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
+++ b/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
@@ -91,76 +91,74 @@ export default function AdminsSchedule() {
               면접에 들어갈 면접관 수에 맞게 클릭해 확정해 주세요.
             </div>
           </div>
-          <div className=" ">
-            <div className="mt-[16px] h-auto pt-[29px] px-[30px] pb-[40px] bg-white-100 rounded-[12px]">
-              <p className="text-main-100 text-caption3 text-left">
-                면접에 들어갈 2명을 선택해 주세요. 2명이 가능한 시간을 이후에
-                지원자들이 선택할 수 있습니다.
-              </p>
-              <div
-                className={`mt-3 border  rounded-[12px] bg-[#FBFBFF]
+          <div className="mt-[16px] h-auto pt-[29px] px-[30px] pb-[40px] bg-white-100 rounded-[12px]">
+            <p className="text-main-100 text-caption3 text-left">
+              면접에 들어갈 2명을 선택해 주세요. 2명이 가능한 시간을 이후에
+              지원자들이 선택할 수 있습니다.
+            </p>
+            <div
+              className={`mt-3 border  rounded-[12px] bg-[#FBFBFF]
               ${isSubmitted && errors.scheduleData ? "border-red-100" : "border-gray-300"}`}
-              >
-                <div className="flex-center bg-gray-200 border-b-[#C7C7CC rounded-t-[12px] pt-[15px] pb-[14px] text-headline">
-                  <img
-                    src="/assets/ic-prevDate.svg"
-                    alt="이전 날짜"
-                    className="mr-[6px]"
-                  />
-                  <p>10월 13일 월요일</p> {/*날짜*/}
-                  <img
-                    src="/assets/ic-nextDate.svg"
-                    alt="다음 날짜"
-                    className="ml-[6px]"
-                  />
-                </div>
-                <div className="pt-2 pb-[10px] pl-[11px]">
-                  <input
-                    type="hidden"
-                    {...register("scheduleData", {
-                      validate: validateScheduleData
-                    })}
-                  />
-                  {timeSlots.map((timeSlot) => (
-                    <div
-                      key={timeSlot}
-                      className="flex items-center space-x-[7px] mb-[13px] "
-                    >
-                      {/*시간*/}
-                      <div
-                        className={`flex-center w-[77.85px] mr-[3.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border 
-                          ${getSelectedAdminCount(timeSlot) >= 2 ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2`}
-                      >
-                        {timeSlot}
-                      </div>
-                      {/*운영진들 */}
-                      {admins.map((admin) => (
-                        <button
-                          key={`${timeSlot}-${admin}`}
-                          type="button"
-                          onClick={() => handleAdminSelect(timeSlot, admin)}
-                          disabled={
-                            getSelectedAdminCount(timeSlot) >= 2 &&
-                            !isAdminSelectedForTimeSlot(timeSlot, admin)
-                          }
-                          className={`flex-center w-[77.85px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]
-                            ${isAdminSelectedForTimeSlot(timeSlot, admin) ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover-not-allowed`}
-                        >
-                          {admin}
-                        </button>
-                      ))}
-                    </div>
-                  ))}
-                </div>
+            >
+              <div className="flex-center bg-gray-200 border-b-[#C7C7CC rounded-t-[12px] pt-[15px] pb-[14px] text-headline">
+                <img
+                  src="/assets/ic-prevDate.svg"
+                  alt="이전 날짜"
+                  className="mr-[6px]"
+                />
+                <p>10월 13일 월요일</p> {/*날짜*/}
+                <img
+                  src="/assets/ic-nextDate.svg"
+                  alt="다음 날짜"
+                  className="ml-[6px]"
+                />
               </div>
-              {isSubmitted && errors.scheduleData?.message && (
-                <p className="text-state-error">
-                  {String(errors.scheduleData.message)}
-                </p>
-              )}
+              <div className="pt-2 pb-[10px] pl-[11px]">
+                <input
+                  type="hidden"
+                  {...register("scheduleData", {
+                    validate: validateScheduleData
+                  })}
+                />
+                {timeSlots.map((timeSlot) => (
+                  <div
+                    key={timeSlot}
+                    className="flex items-center space-x-[7px] mb-[13px] "
+                  >
+                    {/*시간*/}
+                    <div
+                      className={`flex-center w-[77.85px] mr-[3.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border 
+                          ${getSelectedAdminCount(timeSlot) >= 2 ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2`}
+                    >
+                      {timeSlot}
+                    </div>
+                    {/*운영진들 */}
+                    {admins.map((admin) => (
+                      <button
+                        key={`${timeSlot}-${admin}`}
+                        type="button"
+                        onClick={() => handleAdminSelect(timeSlot, admin)}
+                        disabled={
+                          getSelectedAdminCount(timeSlot) >= 2 &&
+                          !isAdminSelectedForTimeSlot(timeSlot, admin)
+                        }
+                        className={`flex-center w-[77.85px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]
+                            ${isAdminSelectedForTimeSlot(timeSlot, admin) ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover-not-allowed`}
+                      >
+                        {admin}
+                      </button>
+                    ))}
+                  </div>
+                ))}
+              </div>
             </div>
-            <button type="submit">임시 제출 버튼</button>
+            {isSubmitted && errors.scheduleData?.message && (
+              <p className="text-state-error">
+                {String(errors.scheduleData.message)}
+              </p>
+            )}
           </div>
+          <button type="submit">임시 제출 버튼</button>
         </div>
       </div>
     </form>

--- a/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
+++ b/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
@@ -10,7 +10,7 @@ export default function AdminsSchedule() {
     trigger
   } = useForm<AdminsScheduleFormData>({
     defaultValues: { scheduleData: {} },
-    mode: "onSubmit"
+    mode: "onBlur"
   });
 
   // 각 시간대별 선택된 면접관을 관리하는 상태
@@ -71,7 +71,7 @@ export default function AdminsSchedule() {
   const validateScheduleData = (value: TimeSlotAdmins) => {
     // 선택된 모든 시간대에서 면접관이 2명인지 확인
     const hasIncompleteSlot = Object.values(value).some(
-      (admins) => admins.length === 2
+      (admins) => admins.length < 2
     );
     return Object.keys(value).length === 0 || hasIncompleteSlot
       ? "필수 선택 사항입니다"

--- a/src/components/recruting/_02_prepare/_04/ScheduleInterviewsContainer.tsx
+++ b/src/components/recruting/_02_prepare/_04/ScheduleInterviewsContainer.tsx
@@ -1,4 +1,10 @@
+import AdminsSchedule from "./AdminsSchedule";
+
 //2-1 운영진 면접 일정 조정 (컨테이너)
 export default function ScheduleInterviewsContainer() {
-  return <div className="w-[1100px]">운영진 면접 일정 조정</div>;
+  return (
+    <div className="w-[1100px]">
+      <AdminsSchedule />
+    </div>
+  );
 }

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -92,14 +92,14 @@ declare interface GroupStore {
   removeGroup: (groupToRemove: string) => void;
 }
 
-interface Step {
+declare interface Step {
   id: number;
   name: string;
   admins: string[];
   isFixed?: boolean;
 }
 
-interface PrepareStepRolesFormValues {
+declare interface PrepareStepRolesFormValues {
   steps: Step[];
 }
 
@@ -115,13 +115,13 @@ declare interface CommonIdeal {
 }
 
 //그룹별 인재상
-interface GroupIdealForm {
+declare interface GroupIdealForm {
   groupIdeals: {
     [groupName: string]: string;
   };
 }
 
-interface GroupIdeals {
+declare interface GroupIdeals {
   [groupName: string]: {
     ideals: GroupIdeal[];
     showInput: boolean;
@@ -130,10 +130,10 @@ interface GroupIdeals {
   };
 }
 
-interface AdminsScheduleFormData {
+declare interface AdminsScheduleFormData {
   scheduleData: TimeSlotAdmins;
 }
 
-interface TimeSlotAdmins {
+declare interface TimeSlotAdmins {
   [timeSlot: string]: string[];
 }

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -129,3 +129,11 @@ interface GroupIdeals {
     nextId: number;
   };
 }
+
+interface AdminsScheduleFormData {
+  scheduleData: TimeSlotAdmins;
+}
+
+interface TimeSlotAdmins {
+  [timeSlot: string]: string[];
+}


### PR DESCRIPTION
## ✅ 면접관 일정 확인 컴포넌트
  const admins = ["박시현", "윤다인", "곽서연", "최예은"];
 const timeSlots = [
    "9:00AM",
    "10:00AM",
    "11:00AM",
    "2:00PM",
    "3:00PM",
    "4:00PM"
   ];
   이렇게 임의로 시간대와 임원진 써놨습니다!

## ✨ Done

- [x] 면접관 일정 확인 컴포넌트 UI
- [x] 폼 처리 및 에러 처리  

## 📸 스크린샷
저도 영상 한 번 넣어봣슴미다..헿... 근데 서연님처럼 움짤이 아니긴 하네요,,흑
https://github.com/user-attachments/assets/9edbbc4a-d2d4-4b18-b210-4997994035a3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 면접관 일정 확인을 위한 역할 분담 UI 업데이트.
	- 면접관을 특정 시간대에 배정하는 `AdminsSchedule` 컴포넌트 추가.
- **버그 수정**
	- UI 텍스트 및 툴팁 수정으로 사용자 지침 개선.
- **문서화**
	- 새로운 인터페이스 `AdminsScheduleFormData` 및 `TimeSlotAdmins` 추가.
	- 기존 인터페이스의 선언 스타일 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->