### PR TITLE
 feat: 3-1 서류 평가 준비하기

### DIFF
--- a/public/assets/ic-minusCircleGray600.svg
+++ b/public/assets/ic-minusCircleGray600.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12.5" r="12" fill="#D0D4E7"/>
+<path d="M17.3281 12.5H6.66146" stroke="#727586" stroke-width="2.25" stroke-linecap="round"/>
+</svg>

--- a/public/assets/ic-plusGray500.svg
+++ b/public/assets/ic-plusGray500.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 1V13" stroke="#8B8FA4" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M13 7L0.999999 7" stroke="#8B8FA4" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -61,7 +61,7 @@
   }
 
   .section-title {
-    @apply text-title3 pr-[21px] flex items-center;
+    @apply text-title3 pr-[21px] flex items-center text-[#3B3D46];
   }
   .tooltip {
     @apply w-auto h-[34px] px-[13.37px] rounded-[11px] bg-white-100 border border-gray-200 text-caption3 text-gray-900 flex-center;

--- a/src/App.css
+++ b/src/App.css
@@ -61,7 +61,7 @@
   }
 
   .section-title {
-    @apply text-title3 pr-[21px] flex items-center text-[#3B3D46];
+    @apply text-title3 pr-[21px] flex items-center text-gray-1100;
   }
   .tooltip {
     @apply w-auto h-[34px] px-[13.37px] rounded-[11px] bg-white-100 border border-gray-200 text-caption3 text-gray-900 flex-center;

--- a/src/components/recruting/_01_plan/AddAdminDropdown.tsx
+++ b/src/components/recruting/_01_plan/AddAdminDropdown.tsx
@@ -11,7 +11,7 @@ export default function AddAdminDropdown({
 }: AddAdminDropdownProps) {
   return (
     <div className="absolute animate-dropdown top-[53.5px] bg-white-100 w-[139px] rounded-[12px]">
-      <ul className="flex-center flex-col h-full p-2 text-body text-[#3B3D46]">
+      <ul className="flex-center flex-col h-full p-2 text-body text-gray-1100">
         {ALL_ADMINS.map((admin: string) => (
           <li
             key={admin}

--- a/src/components/recruting/_01_plan/PrepareStepRoles.tsx
+++ b/src/components/recruting/_01_plan/PrepareStepRoles.tsx
@@ -119,14 +119,14 @@ export default function PrepareStepRoles() {
           <div className="flex">
             {/* 왼쪽 열 */}
             <div className="bg-main-300 border-r border-gray-400 rounded-l-[10px] flex flex-col">
-              <div className="flex-center w-[63.89px] h-[103.8px] border-b border-gray-400 text-[#3B3D46] text-caption1">
+              <div className="flex-center w-[63.89px] h-[103.8px] border-b border-gray-400 text-gray-1100 text-caption1">
                 <p>
                   준비
                   <br />
                   단계
                 </p>
               </div>
-              <div className="flex-1 min-h-[329px] flex-center text-[#3B3D46] text-caption1">
+              <div className="flex-1 min-h-[329px] flex-center text-gray-1100 text-caption1">
                 권한자
               </div>
             </div>

--- a/src/components/recruting/_01_plan/PrepareStepRoles.tsx
+++ b/src/components/recruting/_01_plan/PrepareStepRoles.tsx
@@ -104,13 +104,13 @@ export default function PrepareStepRoles() {
           </div>
         </div>
 
-        <button
+        {/* <button
           type="button"
           className="w-[118px] h-[38px] flex-center bg-main-300 border border-main-400 rounded-[7px] text-caption3 text-main-100 hover:bg-main-100 hover:text-white-100 hover:border-main-100"
           onClick={() => setNewStepName(" ")}
         >
           + 단계 추가
-        </button>
+        </button> */}
       </div>
       <div className="pl-[47px] pr-[48px]">
         <div

--- a/src/components/recruting/_02_prepare/_02/CommonIdeal.tsx
+++ b/src/components/recruting/_02_prepare/_02/CommonIdeal.tsx
@@ -59,7 +59,7 @@ export default function CommonIdeal() {
               key={ideal.id}
               className="mt-[14px] py-[11px] pl-[21px] pr-[53px] bg-white-100 rounded-[8px] border border-gray-500 text-[15px] font-medium flex justify-between items-center"
             >
-              <span className="text-[#3B3D46]">{ideal.text}</span>
+              <span className="text-gray-1100">{ideal.text}</span>
               <button
                 type="button"
                 onClick={() => onRemove(ideal.id)}

--- a/src/components/recruting/_02_prepare/_02/GroupIdeal.tsx
+++ b/src/components/recruting/_02_prepare/_02/GroupIdeal.tsx
@@ -91,7 +91,7 @@ export default function GroupIdeal() {
                   key={ideal.id}
                   className="mt-[14px] py-[11px] pl-[21px] pr-[53px] bg-white-100 rounded-[8px] border border-gray-500 text-[15px] font-medium flex justify-between items-center"
                 >
-                  <span className="text-[#3B3D46]">{ideal.text}</span>
+                  <span className="text-gray-1100">{ideal.text}</span>
                   <button
                     type="button"
                     onClick={() => onRemove(group.name, ideal.id)}

--- a/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
+++ b/src/components/recruting/_02_prepare/_04/AdminsSchedule.tsx
@@ -128,7 +128,7 @@ export default function AdminsSchedule() {
                     {/*시간*/}
                     <div
                       className={`flex-center w-[77.85px] mr-[3.15px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border 
-                          ${getSelectedAdminCount(timeSlot) >= 2 ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2`}
+                          ${getSelectedAdminCount(timeSlot) >= 2 ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-gray-1100"} text-caption2`}
                     >
                       {timeSlot}
                     </div>
@@ -143,7 +143,7 @@ export default function AdminsSchedule() {
                           !isAdminSelectedForTimeSlot(timeSlot, admin)
                         }
                         className={`flex-center w-[77.85px] h-7 bg-[#FBFBFF] rounded-[6px] cursor-pointer border hover:bg-gray-800 hover:border-gray-800 hover:text-[#F2F2F7]
-                            ${isAdminSelectedForTimeSlot(timeSlot, admin) ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-[#3B3D46]"} text-caption2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover-not-allowed`}
+                            ${isAdminSelectedForTimeSlot(timeSlot, admin) ? "border-gray-800 bg-gray-800 text-[#F2F2F7]" : "border-[#E5E5EA] text-gray-1100"} text-caption2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover-not-allowed`}
                       >
                         {admin}
                       </button>

--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -6,7 +6,6 @@ import ApplicantGroup from "./ApplicationGroup";
 import { v4 as uuidv4 } from "uuid";
 import { useForm } from "react-hook-form";
 import GroupQuestion from "./GroupQuestion";
-import { watch } from "fs";
 
 export default function CreateApplicationFormContainer(): ReactElement {
   const [openDropdowns, setOpenDropdowns] = useState<{

--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -134,7 +134,7 @@ export default function CreateApplicationFormContainer(): ReactElement {
         </div>
 
         <div className="mt-[12px] h-auto pt-[32px] pl-[31px] pr-[42px] pb-[32px] bg-white-100 rounded-[12px]">
-          <p className="mb-[15px] text-title3 text-[#3B3D46] text-left text-title3">
+          <p className="mb-[15px] text-title3 text-gray-1100 text-left text-title3">
             공통 질문 관련 주의 사항
           </p>
           <input
@@ -146,7 +146,7 @@ export default function CreateApplicationFormContainer(): ReactElement {
 
           <div className="flex-center my-[42px] border border-gray-200 "></div>
 
-          <p className="mb-[15px] text-title3 text-[#3B3D46] text-left">
+          <p className="mb-[15px] text-title3 text-gray-1100 text-left">
             공통 질문 추가하기
           </p>
           <div className="">
@@ -374,7 +374,7 @@ export default function CreateApplicationFormContainer(): ReactElement {
           </div>
         </div>
         <div className="w-full mt-[12px] px-[30px] py-[20.5px] bg-white-100 rounded-[12px]">
-          <div className="flex flex-col gap-[12px] py-[28px] px-[26px] bg-[#FBFBFF] rounded-[12px] border border-gray-300 text-caption1 text-[#3B3D46]">
+          <div className="flex flex-col gap-[12px] py-[28px] px-[26px] bg-[#FBFBFF] rounded-[12px] border border-gray-300 text-caption1 text--gray-1100">
             {/*이렇게 한 묶음 */}
             <div className="flex">
               <div className="flex-center mr-[13px] w-[88px] h-[28px] bg-gray-200 border border-[#E5E5EA] rounded-[6px]">

--- a/src/components/recruting/_02_prepare/_05/GroupQuestion.tsx
+++ b/src/components/recruting/_02_prepare/_05/GroupQuestion.tsx
@@ -116,7 +116,7 @@ export default function GroupQuestion() {
       </div>
 
       <div className="mt-[12px] h-auto pt-[32px] pl-[31px] pr-[42px] pb-[32px] bg-white-100 rounded-[12px]">
-        <p className="text-title3 text-[#3B3D46] text-left ">지원 그룹</p>
+        <p className="text-title3 text-gray-1100 text-left ">지원 그룹</p>
         <div className="flex items-left mt-[11px] gap-[11px]">
           {group.map((groupName) => (
             <button
@@ -131,7 +131,7 @@ export default function GroupQuestion() {
         </div>
         <div className="flex-center my-[42px] border border-gray-200 "></div>
 
-        <p className="mb-[15px] text-title3 text-[#3B3D46] text-left text-title3">
+        <p className="mb-[15px] text-title3 text-gray-1100 text-left text-title3">
           '{selectedGroup}' 그룹 질문 관련 주의 사항
         </p>
 
@@ -142,7 +142,7 @@ export default function GroupQuestion() {
           {...register("groupQuestionCaution")}
         />
         <div className="flex-center my-[42px] border border-gray-200 "></div>
-        <p className="mb-[15px] text-title3 text-[#3B3D46] text-left">
+        <p className="mb-[15px] text-title3 text-gray-1100 text-left">
           그룹별 질문 추가하기
         </p>
 

--- a/src/components/recruting/_02_prepare/_05/GroupQuestion.tsx
+++ b/src/components/recruting/_02_prepare/_05/GroupQuestion.tsx
@@ -320,7 +320,7 @@ export default function GroupQuestion() {
               className="absolute top-0 left-0 opacity-0 group-hover:opacity-100 "
             />
           </div>
-          질문 추가하기
+          <span className="text-callout">질문 추가하기</span>
         </button>
       </div>
     </form>

--- a/src/components/recruting/_03_document_evaluation/TopSection.tsx
+++ b/src/components/recruting/_03_document_evaluation/TopSection.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { STEP2_ITEMS } from "../../../constants/recruting";
+import {
+  useRecruitmentStepStore,
+  useTopSectionStore
+} from "../../../store/useStore";
+import AddAdmin from "../home/AddAdmin";
+
+export default function TopSection() {
+  const { currentStep, setCurrentStep } = useTopSectionStore();
+  const { currentRecruitmentStep, setCurrentRecruitmentStep } =
+    useRecruitmentStepStore(); //전체 스텝
+  //TODO: 이 섹션에서 전체 스텝 2로 설정하기
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [showAdmin, setShowAdmin] = useState(false); //권한자 보기 드롭다운
+
+  const handleMouseEnter = (index: number) => {
+    setHoveredIndex(index);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredIndex(null);
+  };
+
+  const handleItemClick = (index: number) => {
+    setCurrentStep(index); // 현재 단계를 업데이트
+  };
+
+  return (
+    <div>
+      <div className="relative flex justify-between items-center pl-8 mb-[9px] text-left">
+        <div className="flex items-center">
+          <div className="flex-center mr-3 w-[33px] h-[30px] bg-white-100 border border-gray-500 rounded-[8px]">
+            2
+          </div>
+          <h1 className="text-title1 mr-3">
+            {currentRecruitmentStep || "리크루팅 준비하기"}
+          </h1>
+          <p className="text-headline">
+            {`> (${currentStep + 1}) ${STEP2_ITEMS[currentStep]}`}
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setShowAdmin(!showAdmin);
+          }}
+          className="text-gray-700 hover:underline"
+        >
+          권한자 보기{" "}
+        </button>
+
+        {showAdmin && <AddAdmin isDropdown />}
+      </div>
+      <div className="w-full h-[110px] flex-center bg-white-100 ml-8 my-4 px-8 rounded-[12px]">
+        {STEP2_ITEMS.map((item, index) => (
+          <div key={index} className="flex items-center">
+            <div
+              className={`w-[174px] h-[64px] flex-center mx-[6px] px-[28px] rounded-[8px] text-subheadline ${
+                currentStep === index
+                  ? "bg-main-100 text-white-100"
+                  : "bg-main-300 text-gray-900"
+              }`}
+              onMouseEnter={() => handleMouseEnter(index)}
+              onMouseLeave={handleMouseLeave}
+              onClick={() => handleItemClick(index)} // 클릭 시 단계 변경
+            >
+              {item}
+            </div>
+            <img
+              src={
+                hoveredIndex === index
+                  ? "/assets/ic-nextHover.svg"
+                  : "/assets/ic-next.svg"
+              }
+              alt="다음 클릭"
+              className="w-[6.5px] h-[13px] mx-2"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/recruting/_03_document_evaluation/TopSection.tsx
+++ b/src/components/recruting/_03_document_evaluation/TopSection.tsx
@@ -30,10 +30,10 @@ export default function TopSection() {
       <div className="relative flex justify-between items-center pl-8 mb-[9px] text-left">
         <div className="flex items-center">
           <div className="flex-center mr-3 w-[33px] h-[30px] bg-white-100 border border-gray-500 rounded-[8px]">
-            2
+            3
           </div>
           <h1 className="text-title1 mr-3">
-            {currentRecruitmentStep || "리크루팅 준비하기"}
+            {currentRecruitmentStep || "서류 평가하기"}
           </h1>
           <p className="text-headline">
             {`> (${currentStep + 1}) ${STEP3_ITEMS[currentStep]}`}
@@ -54,7 +54,7 @@ export default function TopSection() {
         {STEP3_ITEMS.map((item, index) => (
           <div key={index} className="flex items-center">
             <div
-              className={`w-[174px] h-[64px] flex-center mx-[6px] px-[28px] rounded-[8px] text-subheadline ${
+              className={`w-[469px] h-[62px] flex-center mx-[6px] px-[28px] rounded-[8px] text-subheadline ${
                 currentStep === index
                   ? "bg-main-100 text-white-100"
                   : "bg-main-300 text-gray-900"

--- a/src/components/recruting/_03_document_evaluation/TopSection.tsx
+++ b/src/components/recruting/_03_document_evaluation/TopSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { STEP2_ITEMS } from "../../../constants/recruting";
+import { STEP3_ITEMS } from "../../../constants/recruting";
 import {
   useRecruitmentStepStore,
   useTopSectionStore
@@ -10,7 +10,6 @@ export default function TopSection() {
   const { currentStep, setCurrentStep } = useTopSectionStore();
   const { currentRecruitmentStep, setCurrentRecruitmentStep } =
     useRecruitmentStepStore(); //전체 스텝
-  //TODO: 이 섹션에서 전체 스텝 2로 설정하기
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [showAdmin, setShowAdmin] = useState(false); //권한자 보기 드롭다운
 
@@ -37,7 +36,7 @@ export default function TopSection() {
             {currentRecruitmentStep || "리크루팅 준비하기"}
           </h1>
           <p className="text-headline">
-            {`> (${currentStep + 1}) ${STEP2_ITEMS[currentStep]}`}
+            {`> (${currentStep + 1}) ${STEP3_ITEMS[currentStep]}`}
           </p>
         </div>
         <button
@@ -52,7 +51,7 @@ export default function TopSection() {
         {showAdmin && <AddAdmin isDropdown />}
       </div>
       <div className="w-full h-[110px] flex-center bg-white-100 ml-8 my-4 px-8 rounded-[12px]">
-        {STEP2_ITEMS.map((item, index) => (
+        {STEP3_ITEMS.map((item, index) => (
           <div key={index} className="flex items-center">
             <div
               className={`w-[174px] h-[64px] flex-center mx-[6px] px-[28px] rounded-[8px] text-subheadline ${

--- a/src/components/recruting/_03_document_evaluation/_01/AddAdminDropdown.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/AddAdminDropdown.tsx
@@ -1,0 +1,32 @@
+import { ALL_ADMINS } from "../../../../constants/recruting";
+
+interface AddAdminDropdownProps {
+  onSelect: (admin: string) => void; // 운영진 선택시 호출될 함수
+  currentAdmins: string[]; // 현재 선택된 운영진 목록
+}
+
+export default function AddAdminDropdown({
+  onSelect,
+  currentAdmins
+}: AddAdminDropdownProps) {
+  return (
+    <div className="absolute animate-dropdown top-[53.5px] w-[328px] bg-white-100 rounded-[12px]">
+      <ul className="flex-center flex-col h-full p-2 text-body text-[#3B3D46]">
+        {ALL_ADMINS.map((admin: string) => (
+          <li
+            key={admin}
+            onClick={() => onSelect(admin)}
+            className="w-full h-[40px] rounded-[8px] cursor-pointer hover:bg-gray-200 flex-center"
+          >
+            <p className="text-center text-[#3B3D46] font-medium">
+              {admin}
+              {currentAdmins.includes(admin) && (
+                <span className="ml-2 text-main-100">✓</span>
+              )}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/recruting/_03_document_evaluation/_01/AddAdminDropdown.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/AddAdminDropdown.tsx
@@ -11,14 +11,14 @@ export default function AddAdminDropdown({
 }: AddAdminDropdownProps) {
   return (
     <div className="absolute animate-dropdown top-[53.5px] w-[328px] bg-white-100 rounded-[12px]">
-      <ul className="flex-center flex-col h-full p-2 text-body text-[#3B3D46]">
+      <ul className="flex-center flex-col h-full p-2 text-body text-gray-1100">
         {ALL_ADMINS.map((admin: string) => (
           <li
             key={admin}
             onClick={() => onSelect(admin)}
             className="w-full h-[40px] rounded-[8px] cursor-pointer hover:bg-gray-200 flex-center"
           >
-            <p className="text-center text-[#3B3D46] font-medium">
+            <p className="text-center text-gray-1100 font-medium">
               {admin}
               {currentAdmins.includes(admin) && (
                 <span className="ml-2 text-main-100">✓</span>

--- a/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
@@ -2,16 +2,10 @@ import { useState } from "react";
 import { useGroupStore } from "../../../../store/useStore";
 import AddAdminDropdown from "./AddAdminDropdown";
 
-type GroupWithAdmin = {
-  id: number;
-  groupName: string;
-  admins: string[];
-};
-
 export default function DocumentReviewPrepContainer() {
   const { group } = useGroupStore();
   const [dropdown, setDropdown] = useState(false);
-  const [currentGroupId, setCurrentGroupId] = useState<number>(1); //드롭다운 시 현재 그룹 id
+  const [currentGroupId, setCurrentGroupId] = useState<number | null>(null);
 
   // group+admin 배열
   const [groupsWithAdmins, setGroupsWithAdmins] = useState<GroupWithAdmin[]>(
@@ -213,6 +207,7 @@ export default function DocumentReviewPrepContainer() {
           ) : (
             <button
               type="button"
+              key="all-groups"
               className="flex-center w-[162px] h-[43px] rounded-t-[11px] border border-main-400 border-b-0 text-callout text-white-100 bg-main-100"
             >
               전체
@@ -227,9 +222,11 @@ export default function DocumentReviewPrepContainer() {
             <label className="flex-center text-gray-800 text-[16px] font-bold">
               서류 만점 점수
               <input
-                type="text"
-                className="flex-center w-[89px] h-[38px] ml-2 px-[24px] py-[10px] rounded-[7px] bg-gray-100 text-callout text-gray-700 outline-none"
-                placeholder="100점"
+                type="number"
+                min="0"
+                max="100"
+                className="flex-center w-[89px] h-[38px] ml-2 px-[24px] py-[10px] rounded-[7px] bg-gray-100 text-callout text-gray-700 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none outline-none"
+                placeholder="100"
               />
             </label>
           </div>

--- a/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
@@ -78,12 +78,6 @@ export default function DocumentReviewPrepContainer() {
           ))}
         </div>
 
-        <div className="flex mt-[34px]">
-          <p className="section-title">서류 평가 역할 설정</p>
-          <div className="tooltip">
-            각 그룹별 서류를 평가할 운영진을 분담해 주세요.
-          </div>
-        </div>
         {groupsWithAdmins?.length ? (
           <div>
             <div className="flex mt-[34px]">
@@ -183,14 +177,14 @@ export default function DocumentReviewPrepContainer() {
 
         <div className="flex gap-[15px] mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
           <div className="flex items-center gap-[15px]">
-            <p>전체</p>
+            <p className="text-body">전체</p>
             <div className="flex-center w-auto h-[38px] px-[25px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
               상위 30명
             </div>
           </div>
           {groupsWithAdmins.map((groupItem) => (
             <div key={groupItem.id} className="flex items-center gap-[15px]">
-              <p>{groupItem.groupName}</p>
+              <p className="text-body">{groupItem.groupName}</p>
               <div className="flex-center w-auto h-[38px] px-[25px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
                 상위 30명
               </div>

--- a/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
@@ -61,17 +61,17 @@ export default function DocumentReviewPrepContainer() {
           </div>
         </div>
 
-        <div className="flex gap-[15px] mt-[10px] h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+        <div className="flex gap-[15px] mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
           <div className="flex items-center gap-[15px]">
             <p>전체</p>
-            <div className="flex-center w-[80px] h-[38px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+            <div className="flex-center w-auto h-[38px] px-[20px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
               175명
             </div>
           </div>
           {groupsWithAdmins.map((groupItem) => (
             <div key={groupItem.id} className="flex items-center gap-[15px]">
               <p>{groupItem.groupName}</p>
-              <div className="flex-center w-[80px] h-[38px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+              <div className="flex-center w-auto h-[38px] px-[20px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
                 175명
               </div>
             </div>
@@ -85,7 +85,7 @@ export default function DocumentReviewPrepContainer() {
           </div>
         </div>
 
-        <div className="flex mt-[10px] h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+        <div className="flex mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
           {groupsWithAdmins.map((groupItem) => (
             <div key={groupItem.id} className="mr-4">
               <div className="flex-center w-[286px] h-[46px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-callout text-main-100">
@@ -126,6 +126,105 @@ export default function DocumentReviewPrepContainer() {
               </button>
             </div>
           ))}
+        </div>
+
+        {/*서류 합격자 인원수 */}
+        <div className="flex mt-[34px]">
+          <p className="section-title">서류 합격자 인원수</p>
+          <div className="tooltip">
+            앞서 설정한 서류 합격자 인원 수를 보여드립니다.
+          </div>
+        </div>
+
+        <div className="flex gap-[15px] mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+          <div className="flex items-center gap-[15px]">
+            <p>전체</p>
+            <div className="flex-center w-auto h-[38px] px-[25px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+              상위 30명
+            </div>
+          </div>
+          {groupsWithAdmins.map((groupItem) => (
+            <div key={groupItem.id} className="flex items-center gap-[15px]">
+              <p>{groupItem.groupName}</p>
+              <div className="flex-center w-auto h-[38px] px-[25px] py-[9.5px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+                상위 30명
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/*평가 기준 설정하기*/}
+        <div className="flex mt-[34px]">
+          <p className="section-title">평가 기준 설정하기</p>
+          <div className="tooltip">
+            평가 기준을 설정해 주세요. 설정된 내용은 개별 평가 진행 시,
+            반영됩니다.
+          </div>
+        </div>
+
+        <div className="flex flex-col mt-[10px] w-full h-auto py-[30px] px-[36px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+          <div className="flex items-center justify-between w-full ">
+            <p className="text-gray-800 text-[16px] font-bold underline underline-offset-2">
+              <a href="">지원서 폼 다시 보기</a>
+            </p>
+            <label className="flex-center text-gray-800 text-[16px] font-bold">
+              서류 만점 점수
+              <input
+                type="text"
+                className="flex-center w-[89px] h-[38px] ml-2 px-[24px] py-[10px] rounded-[7px] bg-gray-100 text-callout text-gray-700 outline-none"
+                placeholder="100점"
+              />
+            </label>
+          </div>
+          <div className="w-full h-auto mt-[18px] bg-gray-100 border border-gray-200 px-[21px] py-[23px] rounded-[12px]">
+            <div className="flex justify-between">
+              <div className="flex items-center">
+                <div className="flex-center w-[28px] h-[28px] rounded-full bg-main-400 text-main-100 text-[15.71px] font-bold">
+                  1
+                </div>
+                <input
+                  type="text"
+                  placeholder="평가 기준1"
+                  className="w-[110px] max-w-full h-[40px] ml-3 px-[24px] py-[10px] bg-white-100 border border-gray-200 text-subheadline rounded-[7px] outline-none"
+                />
+              </div>
+              <div className="flex-center">
+                <div className="min-w-[108px] h-[40px] mr-[10px] px-[24px] py-[10px] bg-white-100 border border-gray-200 rounded-[7px] text-subheadline text-gray-500">
+                  0 / 100점
+                </div>
+                <button type="button">
+                  <img src="/assets/ic-minusCircleGray600.svg"></img>
+                </button>
+              </div>
+            </div>
+            <p className="mt-[23px] text-subheadline text-gray-700 text-left">
+              세부 평가 기준
+            </p>
+            <input
+              type="text"
+              placeholder="세부 평가 기준을 입력해 주세요."
+              className="w-full h-[36px] mt-[9px] px-[13px] py-[9px] bg-white-100 border border-gray-200 text-caption1 rounded-[6px] outline-none"
+            />
+          </div>
+
+          <button
+            type="button"
+            className="flex-center w-full h-[54px] mt-[34px] bg-main-300 border border-main-400 rounded-[8px] text-main-100 hover:bg-main-100 hover:text-white-100 group" // group 추가
+          >
+            <div className="relative mr-2">
+              <img
+                alt="질문 추가 버튼"
+                src="/assets/ic-mainColorPlus.svg"
+                className="group-hover:opacity-0 "
+              />
+              <img
+                alt="질문 추가 버튼"
+                src="/assets/ic-whiteColorPlus.svg"
+                className="absolute top-0 left-0 opacity-0 group-hover:opacity-100 "
+              />
+            </div>
+            <span className="text-callout">질문 추가하기</span>
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
@@ -11,7 +11,7 @@ type GroupWithAdmin = {
 export default function DocumentReviewPrepContainer() {
   const { group } = useGroupStore();
   const [dropdown, setDropdown] = useState(false);
-  const [currentGroupId, setCurrentGroupId] = useState<number>(1);
+  const [currentGroupId, setCurrentGroupId] = useState<number>(1); //드롭다운 시 현재 그룹 id
 
   // group+admin 배열
   const [groupsWithAdmins, setGroupsWithAdmins] = useState<GroupWithAdmin[]>(
@@ -84,49 +84,94 @@ export default function DocumentReviewPrepContainer() {
             각 그룹별 서류를 평가할 운영진을 분담해 주세요.
           </div>
         </div>
-
-        <div className="flex mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
-          {groupsWithAdmins.map((groupItem) => (
-            <div key={groupItem.id} className="mr-4">
-              <div className="flex-center w-[286px] h-[46px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-callout text-main-100">
-                {groupItem.groupName}
+        {groupsWithAdmins?.length ? (
+          <div>
+            <div className="flex mt-[34px]">
+              <p className="section-title">서류 평가 역할 설정</p>
+              <div className="tooltip">
+                각 그룹별 서류를 평가할 운영진을 분담해 주세요.
               </div>
-              <div className="mt-4">
-                {groupItem.admins.map((admin) => (
-                  <div
-                    key={admin}
-                    className="relative flex-center w-[286px] h-[43px] mb-[10px] rounded-[10px] border border-gray-300 bg-white-100 text-subheadline"
-                  >
-                    <span className="text-gray-800">{admin}</span>
-                    <img
-                      src="/assets/ic-minusCircle.svg"
-                      alt="운영진 삭제 버튼"
-                      onClick={() => removeAdmin(groupItem.id, admin)}
-                      className="absolute right-[19px] cursor-pointer"
-                    />
+            </div>
+            <div className="flex mt-[10px] w-full h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+              {groupsWithAdmins.map((groupItem) => (
+                <div key={groupItem.id} className="mr-4">
+                  <div className="flex-center w-[286px] h-[46px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-callout text-main-100">
+                    {groupItem.groupName}
                   </div>
-                ))}
+                  <div className="mt-4">
+                    {groupItem.admins.map((admin) => (
+                      <div
+                        key={admin}
+                        className="relative flex-center w-[286px] h-[43px] mb-[10px] rounded-[10px] border border-gray-300 bg-white-100 text-subheadline"
+                      >
+                        <span className="text-gray-800">{admin}</span>
+                        <img
+                          src="/assets/ic-minusCircle.svg"
+                          alt="운영진 삭제 버튼"
+                          onClick={() => removeAdmin(groupItem.id, admin)}
+                          className="absolute right-[19px] cursor-pointer"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    className="relative flex-center w-[286px] h-[46px] mt-[15px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-subheadline text-gray-500"
+                    onClick={() => {
+                      setCurrentGroupId(groupItem.id);
+                      setDropdown(!dropdown);
+                    }}
+                  >
+                    <img src="/assets/ic-plus.svg" className="mr-2" />
+                    <p>운영진 추가</p>
+                    {dropdown && currentGroupId === groupItem.id && (
+                      <AddAdminDropdown
+                        onSelect={handleAdminSelect}
+                        currentAdmins={groupItem.admins}
+                      />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="flex justify-between mt-[34px]">
+              <div className="flex items-center">
+                <p className="section-title">서류 평가 역할 설정</p>
+                <div className="tooltip">
+                  각 그룹별 서류를 평가할 운영진을 분담해 주세요.
+                </div>
               </div>
               <button
                 type="button"
-                className="relative flex-center w-[286px] h-[46px] mt-[15px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-subheadline text-gray-500"
-                onClick={() => {
-                  setCurrentGroupId(groupItem.id);
-                  setDropdown(!dropdown);
-                }}
+                className="flex-center w-[150.93] h-[48.6px] pl-[24.54px] pr-[17.93px] py-[18.23px] bg-main-300 border border-main-400 rounded-[8.95px] text-main-100 hover:bg-main-100 hover:text-white-100 group"
               >
-                <img src="/assets/ic-plus.svg" className="mr-2" />
-                <p>운영진 추가</p>
-                {dropdown && currentGroupId === groupItem.id && (
-                  <AddAdminDropdown
-                    onSelect={handleAdminSelect}
-                    currentAdmins={groupItem.admins}
+                <div className="relative mr-[4.81px]">
+                  <img
+                    alt="질문 추가 버튼"
+                    src="/assets/ic-mainColorPlus.svg"
+                    className="w-[13px] h-[13px] group-hover:opacity-0 "
                   />
-                )}
+                  <img
+                    alt="질문 추가 버튼"
+                    src="/assets/ic-whiteColorPlus.svg"
+                    className="w-[13px] h-[13px] absolute top-0 left-0 opacity-0 group-hover:opacity-100 "
+                  />
+                </div>
+                <span className="text-semibold">그룹 추가하기</span>
               </button>
             </div>
-          ))}
-        </div>
+            <div className="flex mt-[10px] w-full min-h-[318px] py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px] text-body text-gray-400">
+              <p className="flex-center w-full">
+                그룹을 추가해 주세요. <br></br>
+                그룹을 추가하지 않으면, 운영진 모두가 모든 지원자를 평가하게
+                됩니다.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/*서류 합격자 인원수 */}
         <div className="flex mt-[34px]">
@@ -161,8 +206,26 @@ export default function DocumentReviewPrepContainer() {
             반영됩니다.
           </div>
         </div>
-
-        <div className="flex flex-col mt-[10px] w-full h-auto py-[30px] px-[36px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+        <div className="flex mt-[18px]">
+          {groupsWithAdmins?.length ? (
+            groupsWithAdmins.map((groupItem) => (
+              <button
+                type="button"
+                className="flex-center w-[162px] h-[43px] rounded-t-[11px] bg-gray-100 border border-main-400 border-b-0 text-callout text-main-100 focus:bg-main-100 focus:text-white-100"
+              >
+                {groupItem.groupName}
+              </button>
+            ))
+          ) : (
+            <button
+              type="button"
+              className="flex-center w-[162px] h-[43px] rounded-t-[11px] border border-main-400 border-b-0 text-callout text-white-100 bg-main-100"
+            >
+              전체
+            </button>
+          )}
+        </div>
+        <div className="flex flex-col w-full h-auto py-[30px] px-[36px] bg-white-100 border border-[#D6D7DA] rounded-tr-[21px] rounded-bl-[21px] rounded-br-[21px]">
           <div className="flex items-center justify-between w-full ">
             <p className="text-gray-800 text-[16px] font-bold underline underline-offset-2">
               <a href="">지원서 폼 다시 보기</a>

--- a/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
+++ b/src/components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useGroupStore } from "../../../../store/useStore";
+import AddAdminDropdown from "./AddAdminDropdown";
+
+type GroupWithAdmin = {
+  id: number;
+  groupName: string;
+  admins: string[];
+};
+
+export default function DocumentReviewPrepContainer() {
+  const { group } = useGroupStore();
+  const [dropdown, setDropdown] = useState(false);
+  const [currentGroupId, setCurrentGroupId] = useState<number>(1);
+
+  // group+admin 배열
+  const [groupsWithAdmins, setGroupsWithAdmins] = useState<GroupWithAdmin[]>(
+    group.map((groupName, index) => ({
+      id: index + 1,
+      groupName,
+      admins: []
+    }))
+  );
+
+  const handleAdminSelect = (admin: string) => {
+    setGroupsWithAdmins((prevGroups) =>
+      prevGroups.map((group) => {
+        if (group.id === currentGroupId && !group.admins.includes(admin)) {
+          return {
+            ...group,
+            admins: [...group.admins, admin]
+          };
+        }
+        return group;
+      })
+    );
+    setDropdown(false);
+  };
+
+  const removeAdmin = (groupId: number, adminToRemove: string) => {
+    setGroupsWithAdmins((prevGroups) =>
+      prevGroups.map((group) => {
+        if (group.id === groupId) {
+          return {
+            ...group,
+            admins: group.admins.filter((admin) => admin !== adminToRemove)
+          };
+        }
+        return group;
+      })
+    );
+  };
+
+  return (
+    <div className="w-[1016px]">
+      <div className="ml-8 w-full mt-[34px]">
+        <div className="flex">
+          <p className="section-title">전체 지원자 수</p>
+          <div className="tooltip">
+            우리 동아리에 지원한 전체 지원자 수를 보여드립니다.
+          </div>
+        </div>
+
+        <div className="flex gap-[15px] mt-[10px] h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+          <div className="flex items-center gap-[15px]">
+            <p>전체</p>
+            <div className="flex-center w-[80px] h-[38px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+              175명
+            </div>
+          </div>
+          {groupsWithAdmins.map((groupItem) => (
+            <div key={groupItem.id} className="flex items-center gap-[15px]">
+              <p>{groupItem.groupName}</p>
+              <div className="flex-center w-[80px] h-[38px] rounded-[6px] bg-gray-100 text-[16px] font-medium">
+                175명
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex mt-[34px]">
+          <p className="section-title">서류 평가 역할 설정</p>
+          <div className="tooltip">
+            각 그룹별 서류를 평가할 운영진을 분담해 주세요.
+          </div>
+        </div>
+
+        <div className="flex mt-[10px] h-auto py-[28px] pb-[29px] px-[31px] bg-white-100 border border-[#D6D7DA] rounded-[21px]">
+          {groupsWithAdmins.map((groupItem) => (
+            <div key={groupItem.id} className="mr-4">
+              <div className="flex-center w-[286px] h-[46px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-callout text-main-100">
+                {groupItem.groupName}
+              </div>
+              <div className="mt-4">
+                {groupItem.admins.map((admin) => (
+                  <div
+                    key={admin}
+                    className="relative flex-center w-[286px] h-[43px] mb-[10px] rounded-[10px] border border-gray-300 bg-white-100 text-subheadline"
+                  >
+                    <span className="text-gray-800">{admin}</span>
+                    <img
+                      src="/assets/ic-minusCircle.svg"
+                      alt="운영진 삭제 버튼"
+                      onClick={() => removeAdmin(groupItem.id, admin)}
+                      className="absolute right-[19px] cursor-pointer"
+                    />
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="relative flex-center w-[286px] h-[46px] mt-[15px] mr-[17px] bg-gray-100 border border-gray-300 rounded-[7px] text-subheadline text-gray-500"
+                onClick={() => {
+                  setCurrentGroupId(groupItem.id);
+                  setDropdown(!dropdown);
+                }}
+              >
+                <img src="/assets/ic-plus.svg" className="mr-2" />
+                <p>운영진 추가</p>
+                {dropdown && currentGroupId === groupItem.id && (
+                  <AddAdminDropdown
+                    onSelect={handleAdminSelect}
+                    currentAdmins={groupItem.admins}
+                  />
+                )}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recruting/_03_document_evaluation/common/TopSection.tsx
+++ b/src/components/recruting/_03_document_evaluation/common/TopSection.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { STEP3_ITEMS } from "../../../constants/recruting";
+import { STEP3_ITEMS } from "../../../../constants/recruting";
 import {
   useRecruitmentStepStore,
   useTopSectionStore
-} from "../../../store/useStore";
-import AddAdmin from "../home/AddAdmin";
+} from "../../../../store/useStore";
+import AddAdmin from "../../home/AddAdmin";
 
 export default function TopSection() {
   const { currentStep, setCurrentStep } = useTopSectionStore();
@@ -45,7 +45,7 @@ export default function TopSection() {
           }}
           className="text-gray-700 hover:underline"
         >
-          권한자 보기{" "}
+          권한자 보기
         </button>
 
         {showAdmin && <AddAdmin isDropdown />}

--- a/src/pages/Recruting/step3/DocumentEvaluation.tsx
+++ b/src/pages/Recruting/step3/DocumentEvaluation.tsx
@@ -1,11 +1,14 @@
 //3 - 리크루팅 : 서류 평가하기 단계 (페이지)
-
+import DocumentReviewPrepContainer from "../../../components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer";
 import Sidemenu from "../../../components/recruting/common/Sidemenu";
 
 export default function DocumentEvaluation() {
   return (
-    <div className="flex bg-gray-100 px-16 py-9">
+    <div className="flex justify-center pt-6 bg-gray-100">
       <Sidemenu />
+      <div className="w-[1016px]">
+        <DocumentReviewPrepContainer />
+      </div>
     </div>
   );
 }

--- a/src/pages/Recruting/step3/DocumentEvaluation.tsx
+++ b/src/pages/Recruting/step3/DocumentEvaluation.tsx
@@ -1,13 +1,28 @@
 //3 - 리크루팅 : 서류 평가하기 단계 (페이지)
 import DocumentReviewPrepContainer from "../../../components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer";
+import TopSection from "../../../components/recruting/_03_document_evaluation/TopSection";
+//임시로 넣어놨어요
+import CreateApplicationFormContainer from "../../../components/recruting/_02_prepare/_05/CreateApplicationFormContainer";
+
 import Sidemenu from "../../../components/recruting/common/Sidemenu";
+import { useTopSectionStore } from "../../../store/useStore";
+
+type StepComponent = React.FC;
+
+const stepComponents: StepComponent[] = [
+  DocumentReviewPrepContainer,
+  CreateApplicationFormContainer //임시로 넣어놨어요
+];
 
 export default function DocumentEvaluation() {
+  const { currentStep } = useTopSectionStore();
+  const CurrentStepComponent = stepComponents[currentStep];
   return (
     <div className="flex justify-center pt-6 bg-gray-100">
       <Sidemenu />
       <div className="w-[1016px]">
-        <DocumentReviewPrepContainer />
+        <TopSection />
+        <CurrentStepComponent />
       </div>
     </div>
   );

--- a/src/pages/Recruting/step3/DocumentEvaluation.tsx
+++ b/src/pages/Recruting/step3/DocumentEvaluation.tsx
@@ -1,6 +1,6 @@
 //3 - 리크루팅 : 서류 평가하기 단계 (페이지)
 import DocumentReviewPrepContainer from "../../../components/recruting/_03_document_evaluation/_01/DocumentReviewPrepContainer";
-import TopSection from "../../../components/recruting/_03_document_evaluation/TopSection";
+import TopSection from "../../../components/recruting/_03_document_evaluation/common/TopSection";
 //임시로 넣어놨어요
 import CreateApplicationFormContainer from "../../../components/recruting/_02_prepare/_05/CreateApplicationFormContainer";
 

--- a/src/type/type.d.ts
+++ b/src/type/type.d.ts
@@ -181,3 +181,10 @@ declare interface CreateApplicationForm {
   // 포트폴리오 섹션
   hasPortfolio: boolean;
 }
+
+//3-1 group+admin 배열
+declare interface GroupWithAdmin {
+  id: number;
+  groupName: string;
+  admins: string[];
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,7 +56,8 @@ module.exports = {
           700: "#8E8E93", //gray07
           800: "#636366", //gray08
           850: "#5C6067", //gray8.5
-          900: "#3A3A3C" //gray09
+          900: "#3A3A3C", //gray09
+          1100: "#3B3D46" //gray11
         },
         blue: {
           100: "#FFFFFF",


### PR DESCRIPTION
## ✅ 3-1 서류 평가 준비하기

- 서류 평가 역할 설정만 기능 들어가고 나머지는 UI만 구현했습니다

## ✨ Done

- [x] 3-1 그룹 있,없 UI
- [x] 3단계 TopSection

## ✅ 주요 변경사항

- 2단계 TopSection 참고해서 3단계 TopSection 구현해봤습니다(3-2 컴포넌트 명을 몰라서 임시로 아무 컴포넌트 명 넣어놨어요..!) 

#47 closed

## 📸 스크린샷
이번에는 gif로 해봤어요..ㅎㅎ 흐힣
![3-1-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/a8b0e75c-3fc5-465d-ba0e-2c82c45546ab)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 새 `AddAdminDropdown` 컴포넌트 추가: 관리자를 선택할 수 있는 드롭다운 메뉴 제공.
	- `DocumentReviewPrepContainer` 컴포넌트 추가: 문서 검토 준비를 위한 그룹 관리 기능 제공.
	- `TopSection` 컴포넌트 추가: 현재 단계 표시 및 사용자 상호작용 개선.

- **Bug Fixes**
	- 드롭다운 외부 클릭 시 이벤트 리스너 정리 기능 추가.

- **Style**
	- 여러 컴포넌트의 텍스트 색상 변경: `text-[#3B3D46]`에서 `text-gray-1100`으로 수정.
	- `AddAdminDropdown` 및 기타 컴포넌트의 스타일 개선.

- **Chores**
	- `tailwind.config.js`에서 색상 정의 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->