### PR TITLE
refactor: 2-5 추가

### DIFF
--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -453,11 +453,16 @@ export default function CreateApplicationFormContainer(): ReactElement {
                 ))}
               </div>
 
-              <label className="flex items-center mt-[14px] text-subheadline text-gray-900">
+              <label className="relative flex items-center mt-[14px] text-subheadline text-gray-900">
                 <input
                   type="checkbox"
-                  className="w-[18px] h-[18px] mr-2 cursor-pointer appearance-none checked:bg-main-100 border border-gray-300 rounded"
+                  className=" peer w-[18px] h-[18px] mr-2 cursor-pointer appearance-none checked:bg-main-100 border border-gray-300 rounded"
                   {...register("multipleApplicationAllowed")}
+                />
+                <img
+                  src="/assets/ic-check.svg" // 흰색 체크표시만 있는 SVG
+                  alt=""
+                  className="absolute left-[3px] top-[4px] w-[12px] h-[12px] pointer-events-none opacity-0 peer-checked:opacity-100"
                 />
                 다중 지원 가능
                 <span className="ml-[11px] text-main-100 text-caption3">
@@ -642,11 +647,16 @@ export default function CreateApplicationFormContainer(): ReactElement {
         <div className="ml-8 w-full mt-[58px]">
           <div className="flex items-center">
             <p className="section-title">포트폴리오</p>
-            <label className="flex-center text-subheadline text-gray-900">
+            <label className="relative flex-center text-subheadline text-gray-900">
               <input
                 type="checkbox"
-                className="w-[18px] h-[18px] mr-2 cursor-pointer appearance-none checked:bg-main-100 border border-gray-300 rounded"
+                className="peer w-[18px] h-[18px] mr-2 cursor-pointer appearance-none checked:bg-main-100 border border-gray-300 rounded"
                 {...register("portfolio.enabled")}
+              />
+              <img
+                src="/assets/ic-check.svg" // 흰색 체크표시만 있는 SVG
+                alt=""
+                className="absolute left-[3px] top-[4px] w-[12px] h-[12px] pointer-events-none opacity-0 peer-checked:opacity-100"
               />
               포트폴리오 받기
             </label>

--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -259,12 +259,17 @@ export default function CreateApplicationFormContainer(): ReactElement {
         const question = prev[questionId];
         if (question.type !== "객관형 질문") return prev;
 
+        const updatedQuestion = {
+          ...question,
+          options: [...question.options, newOption]
+        };
+
+        // form 값도 업데이트
+        setValue(`commonSection.questions.${questionId}`, updatedQuestion);
+
         return {
           ...prev,
-          [questionId]: {
-            ...question,
-            options: [...question.options, newOption]
-          }
+          [questionId]: updatedQuestion
         };
       });
     } else {
@@ -273,16 +278,24 @@ export default function CreateApplicationFormContainer(): ReactElement {
         const question = groupQuestions.questions[questionId];
         if (question.type !== "객관형 질문") return prev;
 
+        const updatedQuestion = {
+          ...question,
+          options: [...question.options, newOption]
+        };
+
+        // form 값도 업데이트
+        setValue(
+          `groupSections.${section}.questions.${questionId}`,
+          updatedQuestion
+        );
+
         return {
           ...prev,
           [section]: {
             ...groupQuestions,
             questions: {
               ...groupQuestions.questions,
-              [questionId]: {
-                ...question,
-                options: [...question.options, newOption]
-              }
+              [questionId]: updatedQuestion
             }
           }
         };
@@ -300,12 +313,17 @@ export default function CreateApplicationFormContainer(): ReactElement {
         const question = prev[questionId];
         if (question.type !== "객관형 질문") return prev;
 
+        const updatedQuestion = {
+          ...question,
+          options: question.options.filter((opt) => opt.id !== optionId)
+        };
+
+        // form 값도 업데이트
+        setValue(`commonSection.questions.${questionId}`, updatedQuestion);
+
         return {
           ...prev,
-          [questionId]: {
-            ...question,
-            options: question.options.filter((opt) => opt.id !== optionId)
-          }
+          [questionId]: updatedQuestion
         };
       });
     } else {
@@ -314,16 +332,24 @@ export default function CreateApplicationFormContainer(): ReactElement {
         const question = groupQuestions.questions[questionId];
         if (question.type !== "객관형 질문") return prev;
 
+        const updatedQuestion = {
+          ...question,
+          options: question.options.filter((opt) => opt.id !== optionId)
+        };
+
+        // form 값도 업데이트
+        setValue(
+          `groupSections.${section}.questions.${questionId}`,
+          updatedQuestion
+        );
+
         return {
           ...prev,
           [section]: {
             ...groupQuestions,
             questions: {
               ...groupQuestions.questions,
-              [questionId]: {
-                ...question,
-                options: question.options.filter((opt) => opt.id !== optionId)
-              }
+              [questionId]: updatedQuestion
             }
           }
         };

--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -24,11 +24,16 @@ export default function CreateApplicationFormContainer(): ReactElement {
   const [applyGroupSelect, setApplyGroupSelect] = useState<string[]>([]);
 
   const applyGroup = (groupName: string) => {
-    setApplyGroupSelect((prev) =>
-      prev.includes(groupName)
+    setApplyGroupSelect((prev) => {
+      const newSelected = prev.includes(groupName)
         ? prev.filter((name) => name !== groupName)
-        : [...prev, groupName]
-    );
+        : [...prev, groupName];
+
+      // form 값 업데이트
+      setValue("applyGroups", newSelected);
+
+      return newSelected;
+    });
   };
 
   //그룹별 질문 - 지원 그룹 상태 관리
@@ -99,6 +104,7 @@ export default function CreateApplicationFormContainer(): ReactElement {
   } = useForm<CreateApplicationForm>({
     defaultValues: {
       title: "",
+      applyGroups: [],
       commonSection: {
         caution: "",
         questions: commonQuestions

--- a/src/components/recruting/_02_prepare/_05/QuestionItem.tsx
+++ b/src/components/recruting/_02_prepare/_05/QuestionItem.tsx
@@ -79,7 +79,7 @@ export default function QuestionItem({
           <div className="flex">
             <textarea
               placeholder="질문을 작성해 주세요."
-              className="flex leading-[18px] w-[541px] h-[42px] mr-[12px] py-[11px] px-[19px] rounded-[8px] border border-gray-200 outline-none focus:border-main-100 resize-none"
+              className="flex leading-[18px] w-[541px] h-[42px] mr-[12px] py-[11px] px-[19px] rounded-[8px] border border-gray-200 outline-none overflow-hidden focus:border-main-100 resize-none"
               onInput={(e) => {
                 e.currentTarget.style.height = "auto";
                 e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
@@ -177,7 +177,7 @@ export default function QuestionItem({
           <div>
             <textarea
               placeholder="지원자의 답변 작성란 입니다."
-              className="w-full min-h-[91px] mt-[18px] py-[15px] pl-[20px] rounded-[8px] border border-gray-400 outline-none focus:border-main-100"
+              className="w-full min-h-[91px] mt-[18px] py-[15px] pl-[20px] rounded-[8px] border border-gray-400 outline-none overflow-hidden focus:border-main-100"
               disabled
             />
             <div className="flex-center justify-end mt-[10px]">

--- a/src/type/formtype.d.ts
+++ b/src/type/formtype.d.ts
@@ -197,6 +197,7 @@ declare interface QuestionSection {
 
 declare interface CreateApplicationForm {
   title: string;
+  applyGroups: string[];
   commonSection: {
     caution: string;
     questions: Record<string, Question>;


### PR DESCRIPTION
## ✅ refactor: 2-5 추가

- 그룹별로 독립적으로 질문 상태 유지
- 객관형 질문들 폼 처리 수정
- 첫 번째 질문 타입 상태 에러 수정
- 체크박스 표시
- 질문란에 overflow-hidden

## ✨ Done

- [x] 그룹별로 독립적으로 질문 상태 유지
- [x] 객관형 질문들 폼 처리 수정
- [x] 지원 그룹들 폼 처리 받기
- [x] 첫 번째 질문 타입 상태 에러 수정
- [x] 스타일 수정

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/d8a283fb-df4d-44f2-b27a-6ed843db5a1c)
![image](https://github.com/user-attachments/assets/28c39290-ef5a-4300-90ca-01fd1b22c2c4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 지원서 작성 폼 데이터 관리 개선.
	- 질문 유형에 따라 초기 질문 생성 방식 개선.
	- 지원 그룹을 포함한 기본값 업데이트.
	- 체크박스 입력 스타일 및 기능 향상.

- **버그 수정**
	- 질문 유형 변경 시 관련 속성 설정 로직 간소화.

- **문서화**
	- TypeScript 인터페이스에 `applyGroups` 속성 추가 및 `groupName` 속성 타입 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->