### PR TITLE
hotfix: 운영진 프로세스 시연영상 플로우 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import "./App.css";
 import Header from "./components/common/Header";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import Main from "./pages/Main";
 import Login from "./pages/Login";
 import SignUp from "./pages/SignUp";
@@ -25,6 +25,8 @@ import DocumentEval from "./pages/Recruting/step3/DocumentEval";
 import DocumentPrep from "./pages/Recruting/step3/DocumentPrep";
 import InterviewEval from "./pages/Recruting/step5/InterviewEval";
 import InterviewPrep from "./pages/Recruting/step5/InterviewPrep";
+import DayOfInterviewContainer from "./components/recruting/_05_interview_evaluation/_02/_01_dayOfInterview/DayOfInterviewContainer";
+import AfterInterviewContainer from "./components/recruting/_05_interview_evaluation/_02/_02_afterInterview/AfterInterviewContainer";
 
 export default function App() {
   return (
@@ -75,14 +77,16 @@ export default function App() {
               />
               <Route path="05_interview_evaluation">
                 <Route path="interviewPrep" element={<InterviewPrep />} />
-                <Route path="interview" element={<InterviewEval />} />
+                <Route path="interview">
+                  <Route path="day" element={<DayOfInterviewContainer />} />
+                  <Route path="after" element={<AfterInterviewContainer />} />
+                </Route>
               </Route>
               {/* 개별 질문 작성하기 */}
               <Route
                 path="individual_question/:id"
                 element={<ApplicantDocument />}
               />
-              {/* <Route path="answer_record" element={<AnswerRecord />} /> */}
               {/* (면접) 답변 기록하기 */}
               <Route
                 path="answer_record/:intervieweeName"

--- a/src/components/recruting/_01_plan/PrepareStepRoles.tsx
+++ b/src/components/recruting/_01_plan/PrepareStepRoles.tsx
@@ -29,7 +29,6 @@ export default function PrepareStepRoles({
     return admin ? admin.name : `Unknown (ID: ${adminId})`;
   };
 
-  console.log("모집 준비하기 역할 분담 넘어온 데이터", apiPrepareStepRoles);
   useEffect(() => {
     if (apiPrepareStepRoles && apiPrepareStepRoles.length > 0) {
       const updatedSteps = DEFAULT_STEPS.map((step) => {

--- a/src/components/recruting/_01_plan/RecruitingPlanContainer.tsx
+++ b/src/components/recruting/_01_plan/RecruitingPlanContainer.tsx
@@ -73,7 +73,7 @@ export default function RecruitingPlanContainer() {
       planningData
     }: {
       recruitId: number;
-      planningData: PrepareStepRolesFormValues;
+      planningData: PrepareStepPatchFormValues;
     }) => patchPrep(recruitId, planningData),
     {
       onSuccess: (data) => {
@@ -107,19 +107,21 @@ export default function RecruitingPlanContainer() {
 
   const onSubmit = async (data: PrepareStepRolesFormValues) => {
     try {
-      const formattedData = {
-        recruitSchedules: data.recruitSchedules,
-        prepStages: data.prepStages,
+      const formattedPatchData: PrepareStepPatchFormValues = {
+        recruitSchedules: [data.recruitSchedules],
+        prepStages: data.prepStages.map((stage) => ({
+          ...stage,
+          clubUserIds: stage.clubUserIds
+        })),
         applicantGroups: data.applicantGroups
       };
 
-      console.log("Submitting data:", formattedData);
+      console.log("Submitting data:", isEditMode ? formattedPatchData : data);
 
       if (isEditMode) {
-        console.log(data);
         await patchPlanMutation.mutateAsync({
           recruitId: 1,
-          planningData: data
+          planningData: formattedPatchData
         });
       } else {
         await stepPlanMutation.mutateAsync({

--- a/src/components/recruting/_01_plan/service/Prep.ts
+++ b/src/components/recruting/_01_plan/service/Prep.ts
@@ -41,6 +41,7 @@ export async function getPlanningData(recruitId: number) {
   }
 }
 
+//FIX: url 하드코딩
 // PATCH: 계획하기 수정
 export async function patchPrep(
   recruitId: number,

--- a/src/components/recruting/_01_plan/service/Prep.ts
+++ b/src/components/recruting/_01_plan/service/Prep.ts
@@ -44,30 +44,26 @@ export async function getPlanningData(recruitId: number) {
 // PATCH: 계획하기 수정
 export async function patchPrep(
   recruitId: number,
-  data: PrepareStepRolesFormValues
+  data: PrepareStepPatchFormValues
 ) {
-  const url = `https://210.107.205.122:20025/api/v1/prep?recruitId=${recruitId}`;
-  const headers = {
-    accept: "*/*",
-    Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-    "Content-Type": "application/json"
-  };
-
   try {
-    const response = await fetch(url, {
-      method: "PATCH",
-      headers: headers,
-      body: JSON.stringify(data)
-    });
-
-    const text = await response.text();
-    console.log("Response Text:", text);
+    const response = await fetch(
+      `https://210.107.205.122:20025/api/v1/prep?recruitId=${recruitId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "*/*"
+        },
+        body: JSON.stringify(data)
+      }
+    );
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    const responseData = text ? JSON.parse(text) : {};
+    const responseData = await response.json();
     console.log("계획하기 수정 성공:", responseData);
     return responseData;
   } catch (error) {

--- a/src/components/recruting/_01_plan/service/Prep.ts
+++ b/src/components/recruting/_01_plan/service/Prep.ts
@@ -40,3 +40,38 @@ export async function getPlanningData(recruitId: number) {
     throw error;
   }
 }
+
+// PATCH: 계획하기 수정
+export async function patchPrep(
+  recruitId: number,
+  data: PrepareStepRolesFormValues
+) {
+  const url = `https://210.107.205.122:20025/api/v1/prep?recruitId=${recruitId}`;
+  const headers = {
+    accept: "*/*",
+    Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+    "Content-Type": "application/json"
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: headers,
+      body: JSON.stringify(data)
+    });
+
+    const text = await response.text();
+    console.log("Response Text:", text);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const responseData = text ? JSON.parse(text) : {};
+    console.log("계획하기 수정 성공:", responseData);
+    return responseData;
+  } catch (error) {
+    console.error("계획하기 수정 실패:", error);
+    throw error;
+  }
+}

--- a/src/components/recruting/_01_plan/type/Prep.d.ts
+++ b/src/components/recruting/_01_plan/type/Prep.d.ts
@@ -39,6 +39,12 @@ declare interface PrepareStepRolesFormValues {
   applicantGroups: string[];
 }
 
+declare interface PrepareStepPatchFormValues {
+  prepStages: PrepStage[];
+  recruitSchedules: [RecruitSchedule];
+  applicantGroups: string[];
+}
+
 // 계획하기 불러오기
 declare interface PrepareStepRolesFormValues {
   prepStages: PrepStage[];

--- a/src/components/recruting/_02_prepare/_01/RecruitingCalenderPicker.tsx
+++ b/src/components/recruting/_02_prepare/_01/RecruitingCalenderPicker.tsx
@@ -77,7 +77,7 @@ export default function RecrutingCalenderPicker({
         id: String(events.length + 1),
         title,
         start: selectInfo.startStr,
-        end: addDays(new Date(selectInfo.endStr), 0)
+        end: addDays(new Date(selectInfo.endStr), 1)
           .toISOString()
           .split("T")[0],
         allDay: selectInfo.allDay,
@@ -120,10 +120,10 @@ export default function RecrutingCalenderPicker({
       id: clickInfo.event.id,
       title,
       start: start ? start.toISOString().split("T")[0] : "",
-      end: end ? end.toISOString().split("T")[0] : "",
+      end: end ? addDays(new Date(end), -1).toISOString().split("T")[0] : "",
       allDay: clickInfo.event.allDay
     });
-    setEditMode(false); // 수정 모드 비활성화
+    setEditMode(false);
   };
 
   const handleEditEvent = () => {
@@ -135,7 +135,13 @@ export default function RecrutingCalenderPicker({
       setEvents((prevEvents) =>
         prevEvents.map((event) =>
           event.id === selectedEvent.id
-            ? { ...event, start: selectedEvent.start, end: selectedEvent.end }
+            ? {
+                ...event,
+                start: selectedEvent.start,
+                end: addDays(new Date(selectedEvent.end), 1)
+                  .toISOString()
+                  .split("T")[0]
+              }
             : event
         )
       );

--- a/src/components/recruting/_02_prepare/_01/SetAcceptanceCountContainer.tsx
+++ b/src/components/recruting/_02_prepare/_01/SetAcceptanceCountContainer.tsx
@@ -199,6 +199,12 @@ export default function SetAcceptanceCountContainer() {
     }
   };
 
+  useEffect(() => {
+    if (passIdeal) {
+      setStepCompleted(0, true);
+    }
+  }, [passIdeal, setStepCompleted]);
+
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}

--- a/src/components/recruting/_02_prepare/_02/DefineIdealCandidateContainer.tsx
+++ b/src/components/recruting/_02_prepare/_02/DefineIdealCandidateContainer.tsx
@@ -7,6 +7,7 @@ import { useGroupStore } from "../../../../store/useStore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { postPrepare2 } from "./service/Step2";
 import { getPassIdeal } from "../_01/service/Step1";
+import { useEffect } from "react";
 
 export default function DefineIdealCandidateContainer() {
   const { setStepCompleted, steps } = useStepTwoStore();
@@ -91,6 +92,12 @@ export default function DefineIdealCandidateContainer() {
       });
     }
   });
+
+  useEffect(() => {
+    if (ideal && ideal.partIdeals.some((part) => part.content.length > 0)) {
+      setStepCompleted(1, true);
+    }
+  }, [ideal, setStepCompleted]);
 
   return (
     <FormProvider {...methods}>

--- a/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
+++ b/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
@@ -5,8 +5,9 @@ import { BUTTON_TEXT } from "../../../../constants/recruting";
 import { useStepTwoStore } from "../../../../store/useStore";
 import AnnouncementContent from "./AnnouncementContent";
 import AnnouncementDetails from "./AnnouncementDetails";
-import { useMutation } from "@tanstack/react-query";
-import { postPrepare3 } from "../service/Step2";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getPrepare3AnnouncementInfo, postPrepare3 } from "../service/Step2";
+import { useEffect } from "react";
 
 // 리크루팅 아이디 (하드코딩)
 const RECRUIT_ID = 1;
@@ -30,12 +31,25 @@ export default function AnnouncementContainer() {
 
   //Form 제출
   const methods = useForm<AnnouncementForm>();
-  const { handleSubmit } = methods;
+  const { handleSubmit, reset } = methods;
 
   const onSubmit = (data: AnnouncementForm) => {
     console.log(data);
     mutation.mutate(data);
   };
+
+  //FIX:
+  const recruitId = 1;
+  const { data: announcementInfo } = useQuery(
+    ["announcementInfo", recruitId],
+    () => getPrepare3AnnouncementInfo(recruitId)
+  );
+
+  useEffect(() => {
+    if (announcementInfo) {
+      reset(announcementInfo);
+    }
+  }, [announcementInfo, reset]);
 
   return (
     <FormProvider {...methods}>

--- a/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
+++ b/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
@@ -48,6 +48,7 @@ export default function AnnouncementContainer() {
   useEffect(() => {
     if (announcementInfo) {
       reset(announcementInfo);
+      setStepCompleted(2, true);
     }
   }, [announcementInfo, reset]);
 

--- a/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
+++ b/src/components/recruting/_02_prepare/_03/AnnouncementContainer.tsx
@@ -6,8 +6,12 @@ import { useStepTwoStore } from "../../../../store/useStore";
 import AnnouncementContent from "./AnnouncementContent";
 import AnnouncementDetails from "./AnnouncementDetails";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { getPrepare3AnnouncementInfo, postPrepare3 } from "../service/Step2";
-import { useEffect } from "react";
+import {
+  getPrepare3AnnouncementInfo,
+  patchPrepare3,
+  postPrepare3
+} from "../service/Step2";
+import { useEffect, useState } from "react";
 
 // 리크루팅 아이디 (하드코딩)
 const RECRUIT_ID = 1;
@@ -16,15 +20,25 @@ export default function AnnouncementContainer() {
   //현재 단계 완료 여부 (전역 상태)
   const { setStepCompleted, steps } = useStepTwoStore();
 
+  const [isEditMode, setIsEditMode] = useState(false);
+
   // Mutation 설정
   const mutation = useMutation(
     (data: AnnouncementForm) => postPrepare3(RECRUIT_ID, data),
     {
       onSuccess: (data) => {
         console.log("등록 성공", data); // 성공 데이터 처리
-      },
-      onError: (error: any) => {
-        alert(`모집하기3 등록에에 실패하였습니다`);
+      }
+    }
+  );
+
+  const patchMutation = useMutation(
+    (data: AnnouncementForm) => patchPrepare3(RECRUIT_ID, data),
+    {
+      onSuccess: (data) => {
+        console.log("수정 성공", data);
+        setStepCompleted(2, true);
+        setIsEditMode(false);
       }
     }
   );
@@ -34,8 +48,19 @@ export default function AnnouncementContainer() {
   const { handleSubmit, reset } = methods;
 
   const onSubmit = (data: AnnouncementForm) => {
-    console.log(data);
-    mutation.mutate(data);
+    if (isEditMode) {
+      patchMutation.mutate(data);
+    } else {
+      mutation.mutate(data);
+    }
+  };
+
+  const handleButtonClick = () => {
+    if (steps[2].completed && !isEditMode) {
+      setIsEditMode(true);
+    } else {
+      handleSubmit(onSubmit)();
+    }
   };
 
   //FIX:
@@ -55,7 +80,9 @@ export default function AnnouncementContainer() {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)} className=" mb-[147px]">
-        <div className={`${steps[2].completed ? "pointer-events-none" : ""}`}>
+        <div
+          className={`${steps[2].completed && !isEditMode ? "pointer-events-none" : ""}`}
+        >
           <div className="flex items-center mx-8 my-4">
             <h1 className="section-title">
               <span className="text-main-100 mr-[0.25em]">* </span>공고 세부
@@ -78,20 +105,22 @@ export default function AnnouncementContainer() {
         </div>
         <div className="flex justify-center">
           <button
-            type="submit"
-            onClick={() => {
-              setStepCompleted(2, true);
-            }}
+            type="button"
+            onClick={handleButtonClick}
             aria-label={
-              steps[2].completed ? BUTTON_TEXT.EDIT : BUTTON_TEXT.COMPLETE
+              steps[2].completed && !isEditMode
+                ? BUTTON_TEXT.EDIT
+                : BUTTON_TEXT.COMPLETE
             }
             className={`w-[210px] h-[54px] rounded-[11px] mt-[50px] ${
-              steps[2].completed
-                ? "bg-main-400 border border-main-100 text-main-100 " //수정하기
-                : "bg-main-100 text-white-100 " //완료하기
-            }  text-body flex-center hover:bg-main-500`}
+              steps[2].completed && !isEditMode
+                ? "bg-main-400 border border-main-100 text-main-100"
+                : "bg-main-100 text-white-100"
+            } text-body flex-center hover:bg-main-500`}
           >
-            {steps[2].completed ? BUTTON_TEXT.EDIT : BUTTON_TEXT.COMPLETE}
+            {steps[2].completed && !isEditMode
+              ? BUTTON_TEXT.EDIT
+              : BUTTON_TEXT.COMPLETE}
           </button>
         </div>
 

--- a/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
+++ b/src/components/recruting/_02_prepare/_05/CreateApplicationFormContainer.tsx
@@ -127,7 +127,7 @@ export default function CreateApplicationFormContainer(): ReactElement {
   const handleCloseStepCompleteModal = () => setStepCompleteModalOpen(false);
 
   const handleConfirmStepComplete = () => {
-    completeStep(1);
+    completeStep(1, true);
     setStepCompleted(4, true);
     setStepCompleteModalOpen(false);
   };

--- a/src/components/recruting/_02_prepare/service/Step2.ts
+++ b/src/components/recruting/_02_prepare/service/Step2.ts
@@ -23,7 +23,7 @@ export async function getPrepare3AnnouncementInfo(recruitId: number) {
   }
 }
 
-// PATCH: 모집하기(3) - 공고 일부 수정
+//FIX: url 하드코딩
 // PATCH: 모집하기(3) - 공고 일부 수정
 export async function patchPrepare3(recruitId: number, data: AnnouncementForm) {
   try {

--- a/src/components/recruting/_02_prepare/service/Step2.ts
+++ b/src/components/recruting/_02_prepare/service/Step2.ts
@@ -11,6 +11,18 @@ export async function postPrepare3(recruitId: number, data: AnnouncementForm) {
   }
 }
 
+// GET: 모집하기(3) - 공고 정보 가져오기
+export async function getPrepare3AnnouncementInfo(recruitId: number) {
+  try {
+    const response = await Instance.get(`/plan/stage3/${recruitId}`);
+    console.log("성공:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("모집하기(3) 공고 정보 가져오기 GET 실패:", error);
+    throw error;
+  }
+}
+
 // POST: 모집하기(4) - 운영진 면접 일정 조정하기-면접세팅
 export async function postPrepare4InterviewSetup(
   recruitId: number,

--- a/src/components/recruting/_02_prepare/service/Step2.ts
+++ b/src/components/recruting/_02_prepare/service/Step2.ts
@@ -23,6 +23,37 @@ export async function getPrepare3AnnouncementInfo(recruitId: number) {
   }
 }
 
+// PATCH: 모집하기(3) - 공고 일부 수정
+// PATCH: 모집하기(3) - 공고 일부 수정
+export async function patchPrepare3(recruitId: number, data: AnnouncementForm) {
+  try {
+    const token = localStorage.getItem("access_token");
+    const response = await fetch(
+      `https://210.107.205.122:20025/api/v1/plan/stage3/${recruitId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "*/*",
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(data)
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const responseData = await response.json();
+    console.log("성공:", responseData);
+    return responseData;
+  } catch (error) {
+    console.error("모집하기(3) PATCH 실패:", error);
+    throw error;
+  }
+}
+
 // POST: 모집하기(4) - 운영진 면접 일정 조정하기-면접세팅
 export async function postPrepare4InterviewSetup(
   recruitId: number,

--- a/src/components/recruting/_03_document_evaluation/_02/list/FitMemberList.tsx
+++ b/src/components/recruting/_03_document_evaluation/_02/list/FitMemberList.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 interface FitMemberListProps {
   items: Applicant[]; // Applicant 타입의 배열로 변경
   state: string;
+  isDispute?: boolean;
   isEvaluationDone?: boolean;
   onDispute?: (id: string) => void; // 이의제기
   onDecision?: (id: string) => void;
@@ -13,6 +14,7 @@ interface FitMemberListProps {
 const FitMemberList: React.FC<FitMemberListProps> = ({
   items,
   state,
+  isDispute,
   isEvaluationDone,
   onDispute,
   onDecision
@@ -90,12 +92,11 @@ const FitMemberList: React.FC<FitMemberListProps> = ({
                       )
                     ) : null}
 
-                    {isEvaluationDone &&
-                      item.evaluators?.[0]?.state === "평가 완료" && (
-                        <button className="text-caption2 text-main-100 bg-main-300 px-3 py-[6px] rounded-[7px] border border-main-400">
-                          이의 제기
-                        </button>
-                      )}
+                    {state === "평가 완료" && isEvaluationDone && isDispute && (
+                      <button className="text-caption2 text-main-100 bg-main-300 px-3 py-[6px] rounded-[7px] border border-main-400">
+                        이의 제기
+                      </button>
+                    )}
                   </div>
                   <div className="flex flex-col text-left w-28">
                     <div className="text-[13.856px] font-Pretendard font-semibold text-[#3B3D46] leading-normal">

--- a/src/components/recruting/_03_document_evaluation/_02/step/BeforeEvaluation.tsx
+++ b/src/components/recruting/_03_document_evaluation/_02/step/BeforeEvaluation.tsx
@@ -14,13 +14,7 @@ const BeforeEvaluation: React.FC<BeforeEvaluationProps> = ({
   filter,
   sortType
 }) => {
-  const { applicants } = useApplicantEvaluationStore();
   const [filteredData, setFilteredData] = useState<Applicant[]>([]);
-
-  //TODO: 응답받은 데이터 리스트로 렌더링해야함
-  const [applicationData, setApplicationData] = useState<ApplicationResponse[]>(
-    []
-  );
 
   //FIX:
   const recruitId = 1;
@@ -28,7 +22,6 @@ const BeforeEvaluation: React.FC<BeforeEvaluationProps> = ({
     (data: DocBeforeRequest) => postDocBefore(recruitId, data),
     {
       onSuccess: (response) => {
-        console.log("API 호출 성공", response);
         if (response && Array.isArray(response)) {
           const transformedData = transformApiResponse(response);
           setFilteredData(transformedData);
@@ -36,9 +29,6 @@ const BeforeEvaluation: React.FC<BeforeEvaluationProps> = ({
           console.error("API 응답 데이터가 올바르지 않습니다.");
           setFilteredData([]);
         }
-      },
-      onError: (error) => {
-        console.error("API 호출 실패", error);
       }
     }
   );

--- a/src/components/recruting/_03_document_evaluation/_02/step/CompletedEvaluation.tsx
+++ b/src/components/recruting/_03_document_evaluation/_02/step/CompletedEvaluation.tsx
@@ -205,7 +205,7 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
   const handleCloseStepCompleteModal = () => setStepCompleteModalOpen(false);
 
   const handleConfirmStepComplete = () => {
-    completeStep(2);
+    completeStep(2, true);
     setStepCompleted(1, true);
     setStepCompleteModalOpen(false);
   };

--- a/src/components/recruting/_03_document_evaluation/_02/step/CompletedEvaluation.tsx
+++ b/src/components/recruting/_03_document_evaluation/_02/step/CompletedEvaluation.tsx
@@ -15,6 +15,52 @@ import StepCompleteModal from "../../../common/StepCompleteModal";
 import { BUTTON_TEXT } from "../../../../../constants/recruting";
 import DecisionPassFailModal from "../common/DecisionPassFailModal";
 
+interface Applicant {
+  id: string;
+  name: string;
+  phone: string;
+  group: string;
+  incomplete: number;
+  all: number;
+  isPass?: boolean;
+  evaluators?: Evaluator[];
+  isDecisionMode?: boolean;
+  isDisputed?: boolean;
+}
+
+interface ApiResponse {
+  PASS: ApiApplicant[];
+  FAIL: ApiApplicant[];
+}
+
+interface ApiApplicant {
+  id: number;
+  applicantName: string;
+  applicantPhone: string;
+  groupName: string | null;
+  passed: boolean;
+}
+
+const transformApiResponse = (apiData: ApiResponse): Applicant[] => {
+  const transformSingleApplicant = (item: ApiApplicant): Applicant => ({
+    id: item.id.toString(),
+    name: item.applicantName,
+    phone: item.applicantPhone,
+    group: item.groupName || "미지정",
+    incomplete: 0,
+    all: 0,
+    isPass: item.passed,
+    evaluators: undefined,
+    isDecisionMode: false,
+    isDisputed: false
+  });
+
+  const passApplicants = apiData.PASS.map(transformSingleApplicant);
+  const failApplicants = apiData.FAIL.map(transformSingleApplicant);
+
+  return [...passApplicants, ...failApplicants];
+};
+
 interface CompletedEvaluationProps {
   filter: string;
   sortType: string;
@@ -25,73 +71,56 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
   sortType
 }) => {
   const { applicants } = useApplicantEvaluationStore();
-
   const [members, setMembers] = useState<Applicant[]>(applicants);
   const [filteredData, setFilteredData] = useState<Applicant[]>([]);
   const [filteredData2, setFilteredData2] = useState<Applicant[]>([]);
-
-  //TODO: 응답받은 데이터 리스트로 렌더링해야함
-  const [applicationData, setApplicationData] = useState<ApplicationResponse[]>(
-    []
+  const [applicationData, setApplicationData] = useState<ApiResponse | null>(
+    null
   );
 
-  //FIX:
   const recruitId = 1;
   const queryClient = useQueryClient();
   const mutation = useMutation(
     (data: DocBeforeRequest) => postDocComplete(recruitId, data),
     {
-      onSuccess: (response) => {
-        console.log(
-          "서류 평가하기 <평가 완료> 지원서 리스트 불러오기가 성공적으로 실행되었습니다."
-        );
-        setApplicationData(response.data); // 응답 데이터 저장
-        console.log("API 데이터", applicationData);
-      },
-      onError: (error) => {
-        console.error(
-          "서류 평가하기 <평가 완료> 지원서 리스트 불러오기 중 오류 발생:",
-          error
-        );
+      onSuccess: (response: ApiResponse) => {
+        setApplicationData(response);
       }
     }
   );
 
-  // 컴포넌트 마운트 시 POST 요청
   useEffect(() => {
-    const initialData: DocBeforeRequest = {
-      // POST 요청에 필요한 초기 데이터 구성
-      groupName: null,
-      sortOrder: "oldest"
-    };
+    if (applicationData) {
+      const transformedApplicants = transformApiResponse(applicationData);
+
+      setMembers(transformedApplicants);
+    }
+  }, [applicationData]);
+
+  // 컴포넌트 마운트 시 POST 요청
+  const initialData: DocBeforeRequest = {
+    // POST 요청에 필요한 초기 데이터 구성
+    groupName: null,
+    sortOrder: "newest"
+  };
+
+  useEffect(() => {
     console.group(initialData);
     mutation.mutate(initialData);
   }, []); // 빈 의존성 배열로 컴포넌트 마운트 시에만 실행
 
-  const { data: user } = useQuery(["me"], getMe, {
-    onError: (error) => {
-      console.error("유저 본인 정보 조회 실패:", error);
-    }
-  });
+  const { data: user } = useQuery(["me"], getMe);
 
   useEffect(() => {
     // 평가 완료 상태 데이터 필터링
-    if (user) {
-      const completedMembers = members.filter(
-        (item) =>
-          item.evaluators &&
-          item.incomplete === item.all &&
-          item.evaluators.some(
-            (evaluator) =>
-              evaluator.state === "평가 완료" && evaluator.name === user.name
-          )
-      );
+    if (user && applicationData) {
+      const transformedApplicants = transformApiResponse(applicationData);
 
       // 합격자와 불합격자 분리
-      const filteredAccepted = completedMembers.filter(
+      const filteredAccepted = transformedApplicants.filter(
         (item) => item.isPass === true
       );
-      const filteredRejected = completedMembers.filter(
+      const filteredRejected = transformedApplicants.filter(
         (item) => item.isPass === false
       );
 
@@ -112,7 +141,7 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
           : sortData(filteredRejected.filter((item) => item.group === filter))
       );
     }
-  }, [filter, sortType, members]);
+  }, [filter, sortType, applicationData, user]);
 
   const handleDispute = (id: string) => {
     setMembers((prevMembers) =>
@@ -157,9 +186,6 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
     onSuccess: () => {
       console.log("서류 평가 합불 여부 변경 성공");
       queryClient.invalidateQueries(["applicants", recruitId]);
-    },
-    onError: (error) => {
-      console.error("서류 평가 합불 여부 변경 실패:", error);
     }
   });
 
@@ -220,6 +246,7 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
           <FitMemberList
             items={filteredData}
             state="평가 완료"
+            isDispute
             isEvaluationDone
             onDispute={handleDispute}
             onDecision={handleDecisionClick}
@@ -232,6 +259,7 @@ const CompletedEvaluation: React.FC<CompletedEvaluationProps> = ({
             items={filteredData2}
             state="평가 완료"
             isEvaluationDone
+            isDispute
             onDispute={handleDispute}
             onDecision={handleDecisionClick}
           />

--- a/src/components/recruting/_03_document_evaluation/_02/step/DuringEvaluation.tsx
+++ b/src/components/recruting/_03_document_evaluation/_02/step/DuringEvaluation.tsx
@@ -121,17 +121,6 @@ interface DuringEvaluationProps {
   sortType: string; // 정렬 기준
 }
 
-interface Member {
-  id: string;
-  state: string;
-  name: string;
-  phone: string;
-  group: string;
-  incomplete: number;
-  all: number;
-  result?: "합격" | "불합격";
-}
-
 const DuringEvaluation: React.FC<DuringEvaluationProps> = ({
   filter,
   sortType

--- a/src/components/recruting/_03_document_evaluation/type/step3.d.ts
+++ b/src/components/recruting/_03_document_evaluation/type/step3.d.ts
@@ -23,6 +23,16 @@ declare interface DocBeforeRequest {
 }
 
 // <평가 전> 지원서 불러오기 API 응답 형식
+declare interface DocBeforeRequestResponse {
+  evaluationStage: string;
+  applicantName: string;
+  applicantPhone: string;
+  groupName: string;
+  applicationNumClubUser: string;
+  createdAt: string;
+}
+
+// <평가 전> 지원서 불러오기 API 응답 형식
 declare interface ApplicationResponse {
   evaluationStage: string;
   applicantName: string;

--- a/src/components/recruting/_03_document_evaluation/type/step3.d.ts
+++ b/src/components/recruting/_03_document_evaluation/type/step3.d.ts
@@ -42,6 +42,21 @@ declare interface ApplicationResponse {
   createdAt: string;
 }
 
+declare interface DocIngApplicant {
+  evaluationStage: string;
+  applicantName: string;
+  applicantPhone: string;
+  groupName: string;
+  applicationNumClubUser: string;
+  createdAt: string;
+}
+
+// <평가 중> 지원서 불러오기 API 응답 형식
+declare interface DocIngResponse {
+  ING: DocIngApplicant[];
+  EDITABLE: [];
+}
+
 // 서류 평가 전송 API 요청 형식
 interface DocEvaluationRequest {
   criteriaEvaluations: CriteriaEvaluation[];

--- a/src/components/recruting/_04_interview_notification/_01/FailList.tsx
+++ b/src/components/recruting/_04_interview_notification/_01/FailList.tsx
@@ -16,7 +16,7 @@ export default function FailList({ filter, data, byGroup }: FailListProps) {
           <div className="text-[#525252] text-[13.3px] mr-[5px] p-[6px] rounded-[5px] bg-gray-100 ">
             불합격자
           </div>
-          <p className="text-[#6F7278] text-[11px]">{"78"}</p>
+          <p className="text-[#6F7278] text-[11px]">{data?.length}</p>
         </div>
       </div>
       <table className="w-full mt-4">

--- a/src/components/recruting/_04_interview_notification/_01/PassList.tsx
+++ b/src/components/recruting/_04_interview_notification/_01/PassList.tsx
@@ -19,7 +19,7 @@ export default function PassList({ filter, passData, byGroup }: PassListProps) {
           <div className="text-[#525252] text-[13.3px] mr-[5px] p-[6px] rounded-[5px] bg-gray-100 ">
             전체 합격자
           </div>
-          <p className="text-[#6F7278] text-[11px]">{"60"}</p>
+          <p className="text-[#6F7278] text-[11px]">{passData.length}</p>
         </div>
         {byGroup &&
           Object.entries(byGroup).map(([group, count]) => (

--- a/src/components/recruting/_04_interview_notification/_03/PreviewModal.tsx
+++ b/src/components/recruting/_04_interview_notification/_03/PreviewModal.tsx
@@ -110,7 +110,7 @@ export default function PreviewModal({
 
   const [isStepCompleteModalOpen, setStepCompleteModalOpen] = useState(false);
   const handleConfirmStepComplete = () => {
-    completeStep(3); //전체 4단계 완료
+    completeStep(3, true); //전체 4단계 완료
     setStepCompleted(2, true); //4-3 단계 완료
     setStepCompleteModalOpen(false);
     onClose();

--- a/src/components/recruting/_05_interview_evaluation/_02/ScheduleTopSection.tsx
+++ b/src/components/recruting/_05_interview_evaluation/_02/ScheduleTopSection.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 interface ScheduleTopSectionProps {
   schedule: string;
   setSchedule: (value: string) => void;
@@ -9,26 +11,28 @@ export default function ScheduleTopSection({
 }: ScheduleTopSectionProps) {
   return (
     <div className="flex gap-[17px] w-full text-subheadline bg-white-100 rounded-[7px] px-[18.5px] py-[10px]">
-      <div
+      <Link
+        to="/recruting/05_interview_evaluation/interview/day"
         onClick={() => setSchedule("당일")}
         className={`w-full flex-center rounded-[10.63px] py-[14.5px] ${
           schedule === "당일"
             ? "bg-main-400 text-main-100"
             : "bg-main-300 text-gray-800"
-        }  cursor-pointer`}
+        } cursor-pointer`}
       >
         면접 당일
-      </div>
-      <div
+      </Link>
+      <Link
+        to="/recruting/05_interview_evaluation/interview/after"
         onClick={() => setSchedule("이후")}
-        className={`w-full flex-center rounded-[10.63px] ${
+        className={`w-full flex-center rounded-[10.63px] py-[14.5px] ${
           schedule === "이후"
             ? "bg-main-400 text-main-100"
             : "bg-main-300 text-gray-800"
-        }  cursor-pointer`}
+        } cursor-pointer`}
       >
         면접 이후
-      </div>
+      </Link>
     </div>
   );
 }

--- a/src/components/recruting/_05_interview_evaluation/_02/_01_dayOfInterview/DayOfInterviewContainer.tsx
+++ b/src/components/recruting/_05_interview_evaluation/_02/_01_dayOfInterview/DayOfInterviewContainer.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
 import { useInterviewStore } from "../../../../../store/useStore";
 import InterviewTable from "./InterviewTable";
+import ScheduleTopSection from "../ScheduleTopSection";
+import TopSection from "../../common/TopSection";
+import Sidemenu from "../../../common/Sidemenu";
 
 export default function DayOfInterviewContainer() {
   const { interviewStartDate, interviewEndDate } = useInterviewStore(); //면접 기간
@@ -26,39 +29,46 @@ export default function DayOfInterviewContainer() {
     });
   };
 
+  const [schedule, setSchedule] = useState("당일");
+
   return (
-    <div className="w-full ">
-      <section className="w-fit flex text-title3 mt-8 mb-5 bg-white-100 text-gray-1100 rounded-xl py-[14px] px-[26px]">
-        {/* 이전 날짜 버튼 */}
-        {currentDate > new Date(interviewStartDate) && (
-          <button type="button" onClick={goToPreviousDate}>
-            <img
-              src="/assets/ic-prevDate.svg"
-              alt="이전 날짜"
-              className="w-[9px] mr-5"
-            />
-          </button>
-        )}
-        {/* 현재 날짜 표시 */}
-        <p>
-          {currentDate.toLocaleDateString("ko-KR", {
-            month: "long", // '11' -> '11월'
-            day: "numeric", // '6'
-            weekday: "long" // '월' -> '월요일'
-          })}
-        </p>
-        {/* 다음 날짜 버튼 */}
-        {currentDate < new Date(interviewEndDate) && (
-          <button type="button" onClick={goToNextDate}>
-            <img
-              src="/assets/ic-nextDate.svg"
-              alt="다음 날짜"
-              className="w-[9px] ml-5"
-            />
-          </button>
-        )}
-      </section>
-      <InterviewTable />
+    <div className="flex justify-center pt-6 bg-gray-100">
+      <Sidemenu />
+      <div className="flex flex-col gap-7 w-[1016px] pl-8 mb-[143px]">
+        <TopSection />
+        <ScheduleTopSection schedule={schedule} setSchedule={setSchedule} />
+        <section className="w-fit flex text-title3 mt-8 mb-5 bg-white-100 text-gray-1100 rounded-xl py-[14px] px-[26px]">
+          {/* 이전 날짜 버튼 */}
+          {currentDate > new Date(interviewStartDate) && (
+            <button type="button" onClick={goToPreviousDate}>
+              <img
+                src="/assets/ic-prevDate.svg"
+                alt="이전 날짜"
+                className="w-[9px] mr-5"
+              />
+            </button>
+          )}
+          {/* 현재 날짜 표시 */}
+          <p>
+            {currentDate.toLocaleDateString("ko-KR", {
+              month: "long", // '11' -> '11월'
+              day: "numeric", // '6'
+              weekday: "long" // '월' -> '월요일'
+            })}
+          </p>
+          {/* 다음 날짜 버튼 */}
+          {currentDate < new Date(interviewEndDate) && (
+            <button type="button" onClick={goToNextDate}>
+              <img
+                src="/assets/ic-nextDate.svg"
+                alt="다음 날짜"
+                className="w-[9px] ml-5"
+              />
+            </button>
+          )}
+        </section>
+        <InterviewTable />
+      </div>
     </div>
   );
 }

--- a/src/components/recruting/_05_interview_evaluation/_02/_02_afterInterview/AfterInterviewContainer.tsx
+++ b/src/components/recruting/_05_interview_evaluation/_02/_02_afterInterview/AfterInterviewContainer.tsx
@@ -7,6 +7,9 @@ import AfterEvaluation from "../../../_03_document_evaluation/_02/step/AfterEval
 import CompletedEvaluation from "../../../_03_document_evaluation/_02/step/CompletedEvaluation";
 import { useQuery } from "@tanstack/react-query";
 import { getInterviewGroups } from "../../service/Step5";
+import Sidemenu from "../../../common/Sidemenu";
+import TopSection from "../../common/TopSection";
+import ScheduleTopSection from "../ScheduleTopSection";
 
 interface Group {
   groupId: number;
@@ -37,34 +40,43 @@ export default function AfterInterviewContainer() {
     }
   };
 
+  const [schedule, setSchedule] = useState("이후");
+
   const [filter, setFilter] = useState("전체");
   const [sortType, setSortType] = useState("가나다순");
   const filterOptions = useMemo(() => ["전체", ...groups], [groups]);
 
   return (
-    <div className="flex flex-col mt-6">
-      <div className="flex flex-col gap-3">
-        <div className="flex gap-3">
-          <Dropdown
-            label="필터 : "
-            defaultValue="전체"
-            options={filterOptions}
-            onSelect={(value) => setFilter(value)}
-          />
-          <Dropdown
-            label="정렬 : "
-            defaultValue="가나다순"
-            options={["가나다순"]}
-            onSelect={(value) => setSortType(value)}
-          />
+    <div className="flex justify-center pt-6 bg-gray-100">
+      <Sidemenu />
+      <div className="flex flex-col gap-7 w-[1016px] pl-8 mb-[143px]">
+        <TopSection />
+        <ScheduleTopSection schedule={schedule} setSchedule={setSchedule} />
+        <div className="flex flex-col mt-6">
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-3">
+              <Dropdown
+                label="필터 : "
+                defaultValue="전체"
+                options={filterOptions}
+                onSelect={(value) => setFilter(value)}
+              />
+              <Dropdown
+                label="정렬 : "
+                defaultValue="가나다순"
+                options={["가나다순"]}
+                onSelect={(value) => setSortType(value)}
+              />
+            </div>
+            <EvalProcessBar
+              steps={steps}
+              currentStep={currentStep}
+              onStepClick={setCurrentStep}
+            />
+          </div>
+          <div className="mb-8">{renderStepComponent()}</div>
         </div>
-        <EvalProcessBar
-          steps={steps}
-          currentStep={currentStep}
-          onStepClick={setCurrentStep}
-        />
       </div>
-      <div className="mb-8">{renderStepComponent()}</div>
     </div>
   );
 }

--- a/src/components/recruting/_05_interview_evaluation/answer_record/AnswerRecordContainer.tsx
+++ b/src/components/recruting/_05_interview_evaluation/answer_record/AnswerRecordContainer.tsx
@@ -26,7 +26,7 @@ export default function AnswerRecordContainer() {
   return (
     <div className="w-full h-full flex-col ">
       <div className="flex items-center mb-10">
-        <Link to="/recruting/05_interview_evaluation/interview">
+        <Link to="/recruting/05_interview_evaluation/interview/after">
           <img src="/assets/ic-back.svg" alt="뒤로가기" />
         </Link>
         <div className="flex-col justify-start text-left ml-[21px]">

--- a/src/components/recruting/_05_interview_evaluation/common/TopSection.tsx
+++ b/src/components/recruting/_05_interview_evaluation/common/TopSection.tsx
@@ -30,7 +30,7 @@ export default function TopSection() {
 
   const handleItemClick = (index: number) => {
     setCurrentStep(index); // 현재 단계를 업데이트
-    const paths = ["interviewPrep", "interview"];
+    const paths = ["interviewPrep", "interview/day"];
     navigate(`/recruting/05_interview_evaluation/${paths[index]}`);
   };
 

--- a/src/components/recruting/_05_interview_evaluation/interview_evaluation_record/InterviewEvaluationRecordContainer.tsx
+++ b/src/components/recruting/_05_interview_evaluation/interview_evaluation_record/InterviewEvaluationRecordContainer.tsx
@@ -12,7 +12,7 @@ export default function InterviewEvaluationRecordContainer() {
   return (
     <div className="w-fit h-full flex-col items-center relative ">
       <div className="flex items-center gap-2 mb-10 ">
-        <Link to="/recruting/05_interview_evaluation/interview">
+        <Link to="/recruting/05_interview_evaluation/interview/after">
           <img src="/assets/ic-back.svg" alt="뒤로가기" />
         </Link>
         <p className="text-title1 text-gray-1300 mt-1  text-left ml-[21px]">

--- a/src/components/recruting/_06_final_selection/_01/FailList.tsx
+++ b/src/components/recruting/_06_final_selection/_01/FailList.tsx
@@ -20,7 +20,7 @@ export default function FailList({ filter, data, byGroup }: FailListProps) {
           <div className="text-[#525252] text-[13.3px] mr-[5px] p-[6px] rounded-[5px] bg-gray-100 ">
             불합격자
           </div>
-          <p className="text-[#6F7278] text-[11px]">{"78"}</p>
+          <p className="text-[#6F7278] text-[11px]">{data?.length}</p>
         </div>
       </div>
       <table className="w-full mt-4">

--- a/src/components/recruting/_06_final_selection/_01/FailList.tsx
+++ b/src/components/recruting/_06_final_selection/_01/FailList.tsx
@@ -7,9 +7,6 @@ interface FailListProps {
 }
 
 export default function FailList({ filter, data, byGroup }: FailListProps) {
-  //FIX:
-  const status = "완료";
-
   const filteredData =
     filter === "전체" ? data : data?.filter((data) => data.part === filter);
 

--- a/src/components/recruting/_06_final_selection/_01/PassList.tsx
+++ b/src/components/recruting/_06_final_selection/_01/PassList.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-import { useGroupStore } from "../../../../store/useStore";
 import { GetApplicant } from "../../../../type/type";
 
 interface PassListProps {
@@ -9,8 +7,6 @@ interface PassListProps {
 }
 export default function PassList({ filter, passData, byGroup }: PassListProps) {
   //FIX:
-  const status = "완료";
-
   const filteredData =
     filter === "전체"
       ? passData

--- a/src/components/recruting/_06_final_selection/_01/PassList.tsx
+++ b/src/components/recruting/_06_final_selection/_01/PassList.tsx
@@ -23,7 +23,7 @@ export default function PassList({ filter, passData, byGroup }: PassListProps) {
           <div className="text-[#525252] text-[13.3px] mr-[5px] p-[6px] rounded-[5px] bg-gray-100 ">
             전체 합격자
           </div>
-          <p className="text-[#6F7278] text-[11px]">{"60"}</p>
+          <p className="text-[#6F7278] text-[11px]">{passData?.length}</p>
         </div>
         {byGroup &&
           Object.entries(byGroup)?.map(([group, count]) => (

--- a/src/components/recruting/_06_final_selection/_02/PreviewModal.tsx
+++ b/src/components/recruting/_06_final_selection/_02/PreviewModal.tsx
@@ -102,7 +102,7 @@ export default function PreviewModal({
 
   const [isStepCompleteModalOpen, setStepCompleteModalOpen] = useState(false);
   const handleConfirmStepComplete = () => {
-    completeStep(5); //전체 6단계 완료
+    completeStep(5, true); //전체 6단계 완료
     setStepCompleted(1, true); //6-2 단계 완료
     setStepCompleteModalOpen(false); // StepCompleteModal 닫기
     onClose(); // PreviewModal 닫기

--- a/src/components/recruting/common/Sidemenu.tsx
+++ b/src/components/recruting/common/Sidemenu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   PATH,
+  START_PATH,
   STEP2_ITEMS,
   STEP3_ITEMS,
   STEP4_ITEMS,
@@ -183,7 +184,7 @@ export default function Sidemenu() {
           리크루팅 단계
         </p>
         {[...Array(6)].map((_, index) => {
-          const isActive = location.pathname === PATH[index];
+          const isActive = location.pathname.startsWith(START_PATH[index]);
           return (
             <div key={index} onClick={() => handleDropdownClick(index)}>
               <div

--- a/src/components/recruting/common/Sidemenu.tsx
+++ b/src/components/recruting/common/Sidemenu.tsx
@@ -11,6 +11,8 @@ import {
 } from "../../../constants/recruting";
 import { useClubInfoStore } from "../../../store/useStore";
 import { useAuthStore } from "../../../store/useAuthStore";
+import { useQuery } from "@tanstack/react-query";
+import { getRecruitingHome } from "../service/recruiting";
 
 export default function Sidemenu() {
   // 현재 경로 가져오기
@@ -89,7 +91,30 @@ export default function Sidemenu() {
     localStorage.removeItem("refresh_token");
   };
 
-  const { clubProfile, clubName, generation } = useClubInfoStore();
+  // 리크루팅 홈 데이터 조회
+  const params = useParams();
+  const clubId = 1;
+  const recruitId = 1;
+
+  const [clubProfile, setClubProfile] = useState();
+  const [clubName, setClubName] = useState("-");
+  const [generation, setGeneration] = useState("-");
+
+  const { data: recruitingHomeData } = useQuery(
+    ["recruitingHome", recruitId, clubId],
+    () => getRecruitingHome(recruitId, clubId),
+    {
+      onSuccess: (data) => {
+        if (data?.recruitInfo) {
+          const { clubProfile, clubName, generation } = data.recruitInfo;
+          setGeneration(generation);
+          setClubName(clubName);
+          setClubProfile(clubProfile);
+        }
+        // TODO: TopSection에 현재 진행중인 단계 보이도록 데이터 전달
+      }
+    }
+  );
 
   return (
     <div

--- a/src/constants/recruting.ts
+++ b/src/constants/recruting.ts
@@ -16,6 +16,15 @@ export const PATH = [
   "/recruting/06_final_selection"
 ];
 
+export const START_PATH = [
+  "/recruting/01_plan",
+  "/recruting/02_prepare",
+  "/recruting/03_document_evaluation",
+  "/recruting/04_interview_notification",
+  "/recruting/05_interview_evaluation",
+  "/recruting/06_final_selection"
+];
+
 export const STEP2_ITEMS = [
   "합격 인원 설정하기",
   "인재상 구축하기",

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,29 +1,48 @@
 import { create } from "zustand";
 
 // 리크루팅 전체 단계
+// export const useRecruitmentStepStore = create<RecruitmentStore>()((set) => ({
+//   currentRecruitmentStep: 0, // 초기 단계
+//   completedSteps: [] as boolean[], // 각 단계 완료 여부 배열 (초기에는 모두 false로)
+
+//   setCurrentRecruitmentStep: (step: number) =>
+//     set({ currentRecruitmentStep: step }), // 단계 변경
+
+//   // 특정 단계를 완료 상태로 설정하는 메서드
+//   completeStep: (step: number) =>
+//     set((state) => {
+//       const updatedCompletedSteps = [...state.completedSteps];
+//       updatedCompletedSteps[step] = true;
+//       return { completedSteps: updatedCompletedSteps };
+//     }),
+
+//   // 특정 단계의 완료 여부를 취소하는 메서드
+//   resetStepCompletion: (step: number) =>
+//     set((state) => {
+//       const updatedCompletedSteps = [...state.completedSteps];
+//       updatedCompletedSteps[step] = false;
+//       return { completedSteps: updatedCompletedSteps };
+//     })
+// }));
+
 export const useRecruitmentStepStore = create<RecruitmentStore>()((set) => ({
-  currentRecruitmentStep: 0, // 초기 단계
-  completedSteps: [] as boolean[], // 각 단계 완료 여부 배열 (초기에는 모두 false로)
+  currentRecruitmentStep: 0,
+  completedSteps: [] as boolean[],
 
   setCurrentRecruitmentStep: (step: number) =>
-    set({ currentRecruitmentStep: step }), // 단계 변경
+    set({ currentRecruitmentStep: step }),
 
-  // 특정 단계를 완료 상태로 설정하는 메서드
-  completeStep: (step: number) =>
+  // Modified completeStep function
+  completeStep: (step: number, isCompleted: boolean) =>
     set((state) => {
       const updatedCompletedSteps = [...state.completedSteps];
-      updatedCompletedSteps[step] = true;
-      return { completedSteps: updatedCompletedSteps };
-    }),
-
-  // 특정 단계의 완료 여부를 취소하는 메서드
-  resetStepCompletion: (step: number) =>
-    set((state) => {
-      const updatedCompletedSteps = [...state.completedSteps];
-      updatedCompletedSteps[step] = false;
+      updatedCompletedSteps[step] = isCompleted;
       return { completedSteps: updatedCompletedSteps };
     })
+
+  // The resetStepCompletion function can be removed as it's now redundant
 }));
+
 // 리크루팅 모집 준비하기 단계 (2) Top Section
 export const useStepTwoStore = create<Store>()((set) => ({
   currentStep: 0, // 초기 단계

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,30 +1,6 @@
 import { create } from "zustand";
 
 // 리크루팅 전체 단계
-// export const useRecruitmentStepStore = create<RecruitmentStore>()((set) => ({
-//   currentRecruitmentStep: 0, // 초기 단계
-//   completedSteps: [] as boolean[], // 각 단계 완료 여부 배열 (초기에는 모두 false로)
-
-//   setCurrentRecruitmentStep: (step: number) =>
-//     set({ currentRecruitmentStep: step }), // 단계 변경
-
-//   // 특정 단계를 완료 상태로 설정하는 메서드
-//   completeStep: (step: number) =>
-//     set((state) => {
-//       const updatedCompletedSteps = [...state.completedSteps];
-//       updatedCompletedSteps[step] = true;
-//       return { completedSteps: updatedCompletedSteps };
-//     }),
-
-//   // 특정 단계의 완료 여부를 취소하는 메서드
-//   resetStepCompletion: (step: number) =>
-//     set((state) => {
-//       const updatedCompletedSteps = [...state.completedSteps];
-//       updatedCompletedSteps[step] = false;
-//       return { completedSteps: updatedCompletedSteps };
-//     })
-// }));
-
 export const useRecruitmentStepStore = create<RecruitmentStore>()((set) => ({
   currentRecruitmentStep: 0,
   completedSteps: [] as boolean[],

--- a/src/type/storetype.d.ts
+++ b/src/type/storetype.d.ts
@@ -27,8 +27,7 @@ declare interface RecruitmentStore {
 
   // 단계 완료 여부 배열 및 관련 메서드
   completedSteps: boolean[]; // 각 단계의 완료 여부를 저장하는 배열
-  completeStep: (step: number) => void; // 특정 단계를 완료로 설정하는 함수
-  resetStepCompletion: (step: number) => void; // 특정 단계의 완료 여부를 취소하는 함수
+  completeStep: (step: number, isCompleted: boolean) => void; // 특정 단계의 완료 여부를 설정하는 함수
 }
 
 declare interface GroupStore {


### PR DESCRIPTION
## ✅운영진 프로세스 시연영상 플로우 구현

## ✨ Done

- [x] 3단계 평가 전, 중,후,완료 조회 API 연결 및 처리
- [x] 계획하기 수정하기 구현
- [x] 2-3 get 구현
- [x] 2-3 수정하기 구현
- [x] 4-1, 6-1 전체 합격자 수 통일
- [x] 계획하기 캘린더 날자 입력 수정
- [x] 5단계 당일 이전, 이후 url 분리 ->  뒤로가기 문제 해결